### PR TITLE
Add Python components to documentation

### DIFF
--- a/.chronus/changes/feature-python-docs-2025-7-27-14-44-47.md
+++ b/.chronus/changes/feature-python-docs-2025-7-27-14-44-47.md
@@ -1,0 +1,7 @@
+---
+changeKind: feature
+packages:
+  - "@alloy-js/python"
+---
+
+Add Python components to documentation

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "build": "pnpm -r --workspace-concurrency=Infinity build",
     "watch": "tsc --build ./tsconfig.ws.json --watch",
+    "change": "chronus",
     "clean": "pnpm -r run clean && rimraf **/.temp/",
     "test": "vitest run",
     "format": "prettier . --write",

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -25,6 +25,7 @@
     "@alloy-js/core": "workspace:~",
     "@alloy-js/csharp": "workspace:~",
     "@alloy-js/java": "workspace:~",
+    "@alloy-js/python": "workspace:~",
     "@alloy-js/typescript": "workspace:~",
     "@microsoft/api-extractor": "catalog:",
     "@microsoft/api-extractor-model": "catalog:",

--- a/packages/docs/scripts/build-json.ts
+++ b/packages/docs/scripts/build-json.ts
@@ -44,6 +44,7 @@ const apiPackages = {
   csharp: apiModel.loadPackage(apiPath(resolve(packagesPath, "csharp"))),
   java: apiModel.loadPackage(apiPath(resolve(packagesPath, "java"))),
   json: apiModel.loadPackage(apiPath(resolve(packagesPath, "json"))),
+  python: apiModel.loadPackage(apiPath(resolve(packagesPath, "python"))),
 };
 
 function apiPath(packagePath: string) {

--- a/packages/python/src/components/FunctionDeclaration.tsx
+++ b/packages/python/src/components/FunctionDeclaration.tsx
@@ -81,6 +81,12 @@ export function FunctionDeclaration(props: FunctionDeclarationProps) {
   );
 }
 
+export interface InitFunctionDeclarationProps
+  extends Omit<
+    FunctionDeclarationProps,
+    "name" | "instanceFunction" | "classFunction"
+  > {}
+
 /**
  * A Python `__init__` function declaration.
  *
@@ -102,12 +108,7 @@ export function FunctionDeclaration(props: FunctionDeclarationProps) {
  * an instance function, and forces the name to be `__init__` without applying
  * the name policy.
  */
-export function InitFunctionDeclaration(
-  props: Omit<
-    FunctionDeclarationProps,
-    "name" | "instanceFunction" | "classFunction"
-  >,
-) {
+export function InitFunctionDeclaration(props: InitFunctionDeclarationProps) {
   return (
     <NoNamePolicy>
       <FunctionDeclaration

--- a/packages/python/src/components/PythonBlock.tsx
+++ b/packages/python/src/components/PythonBlock.tsx
@@ -1,5 +1,10 @@
 import { Block, Children } from "@alloy-js/core";
 
+export interface PythonBlockProps {
+  children: Children;
+  opener?: string;
+}
+
 /**
  * A Python block component that can be used to render a block of Python code.
  *
@@ -17,7 +22,7 @@ import { Block, Children } from "@alloy-js/core";
  *   y: str = None
  * ```
  */
-export function PythonBlock(props: { children: Children; opener?: string }) {
+export function PythonBlock(props: PythonBlockProps) {
   return (
     <Block opener={props.opener ?? ""} closer="">
       {props.children}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -449,6 +449,9 @@ importers:
       '@alloy-js/java':
         specifier: workspace:~
         version: link:../java
+      '@alloy-js/python':
+        specifier: workspace:~
+        version: link:../python
       '@alloy-js/typescript':
         specifier: workspace:~
         version: link:../typescript


### PR DESCRIPTION
This requires a couple of small changes to the Python components to make them readable by the docs generator.
