### PR TITLE
[Pinterest Only] Add CI checks on pull requests

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,0 +1,50 @@
+name: Pull Request Checks (Pinterest)
+on: pull_request
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: ./.github/actions/setup
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Build
+        run: pnpm build
+
+      - name: Test
+        run: pnpm test
+
+      - name: Generate docs
+        working-directory: ./packages/docs
+        run: pnpm run generate-docs
+
+  format:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup
+
+      - run: pnpm install
+        name: Install dependencies
+
+      - run: pnpm run format:check
+        name: Check formatting
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup
+
+      - run: pnpm install
+        name: Install dependencies
+
+      - run: pnpm run lint
+        name: Lint


### PR DESCRIPTION
GitHub does not run workflows by default in forked repositories; indeed, we do not want to run the workflows in the parent repo (which include things like publishing artifacts).

Instead, we create our own version of the `CI` workflow and will manually disable all the others (so those files can still be updated without merge conflict).