### PR TITLE
Refactor FunctionDeclaration

### DIFF
--- a/packages/python/src/components/CallSignature.tsx
+++ b/packages/python/src/components/CallSignature.tsx
@@ -20,6 +20,7 @@ export interface CallSignatureParametersProps {
   readonly kwargs?: boolean;
   readonly instanceFunction?: boolean;
   readonly classFunction?: boolean;
+  readonly staticFunction?: boolean;
 }
 
 /**
@@ -36,9 +37,12 @@ export interface CallSignatureParametersProps {
  * ```
  */
 export function CallSignatureParameters(props: CallSignatureParametersProps) {
-  // Validate that only one of instanceFunction or classFunction is true
-  if (props.instanceFunction && props.classFunction) {
-    throw new Error("Cannot be both an instance function and a class function");
+  if (
+    [props.instanceFunction, props.classFunction, props.staticFunction].filter(
+      Boolean,
+    ).length > 1
+  ) {
+    throw new Error("A function can only be one of instance, class, or static");
   }
 
   const sfContext = useContext(PythonSourceFileContext);
@@ -183,6 +187,11 @@ export interface CallSignatureProps {
   classFunction?: boolean; // true if this is a class function
 
   /**
+   * Indicates that this is a static function.
+   */
+  staticFunction?: boolean; // true if this is a static function
+
+  /**
    * The return type of the function.
    */
   returnType?: TypeExpressionProps;
@@ -216,6 +225,7 @@ export function CallSignature(props: CallSignatureProps) {
       kwargs={props.kwargs}
       instanceFunction={props.instanceFunction}
       classFunction={props.classFunction}
+      staticFunction={props.staticFunction}
     />
   );
   const typeParams =

--- a/packages/python/src/components/FunctionDeclaration.tsx
+++ b/packages/python/src/components/FunctionDeclaration.tsx
@@ -30,13 +30,14 @@ export interface FunctionDeclarationProps
  *   return a + b
  * ```
  */
-export function FunctionDeclaration(props: FunctionDeclarationProps) {
+function FunctionDeclarationBase(props: FunctionDeclarationProps) {
   const asyncKwd = props.async ? "async " : "";
   const callSignatureProps = getCallSignatureProps(props, {});
   const sym = createPythonSymbol(
     props.name,
     {
-      instance: props.instanceFunction,
+      instance:
+        props.instanceFunction || props.staticFunction || props.classFunction,
       refkeys: props.refkey,
     },
     "function",
@@ -59,20 +60,48 @@ export function FunctionDeclaration(props: FunctionDeclarationProps) {
   );
 }
 
-export interface InitFunctionDeclarationProps
+export function FunctionDeclaration(props: FunctionDeclarationProps) {
+  return <FunctionDeclarationBase {...props} />;
+}
+
+export function MethodDeclaration(props: FunctionDeclarationProps) {
+  return <FunctionDeclarationBase instanceFunction={true} {...props} />;
+}
+
+export function ClassMethodDeclaration(props: FunctionDeclarationProps) {
+  return (
+    <>
+      {"@classmethod"}
+      <hbr />
+      <FunctionDeclarationBase classFunction={true} {...props} />
+    </>
+  );
+}
+
+export function StaticMethodDeclaration(props: FunctionDeclarationProps) {
+  return (
+    <>
+      {"@staticmethod"}
+      <hbr />
+      <FunctionDeclarationBase staticFunction={true} {...props} />
+    </>
+  );
+}
+
+export interface DunderMethodDeclarationProps
   extends Omit<
     FunctionDeclarationProps,
-    "name" | "instanceFunction" | "classFunction"
+    "instanceFunction" | "classFunction" | "staticFunction"
   > {}
 
 /**
- * A Python `__init__` function declaration.
+ * A Python dunder method declaration.
  *
  * @example
  * ```tsx
- * <InitFunctionDeclaration>
+ * <DunderMethodDeclaration name="__init__">
  *   self.attribute = "value"
- * </InitFunctionDeclaration>
+ * </DunderMethodDeclaration>
  * ```
  * This will generate:
  * ```python
@@ -82,19 +111,12 @@ export interface InitFunctionDeclarationProps
  *
  * @remarks
  *
- * This is a convenience component that sets the name to `__init__`, marks it as
- * an instance function, and forces the name to be `__init__` without applying
- * the name policy.
+ * This is a convenience component for dunder methods.
  */
-export function InitFunctionDeclaration(props: InitFunctionDeclarationProps) {
+export function DunderMethodDeclaration(props: DunderMethodDeclarationProps) {
   return (
     <NoNamePolicy>
-      <FunctionDeclaration
-        {...props}
-        name="__init__"
-        instanceFunction={true}
-        classFunction={false}
-      />
+      <MethodDeclaration {...props} />
     </NoNamePolicy>
   );
 }

--- a/packages/python/src/utils.ts
+++ b/packages/python/src/utils.ts
@@ -22,6 +22,7 @@ export function getCallSignatureProps(
     "kwargs",
     "instanceFunction",
     "classFunction",
+    "staticFunction",
     "returnType",
   ]);
 

--- a/packages/python/test/callsignatures.test.tsx
+++ b/packages/python/test/callsignatures.test.tsx
@@ -163,6 +163,17 @@ describe("Call Signature", () => {
       (self, a, b)
     `);
   });
+  it("renders a simple call signature for an instance function", () => {
+    const result = toSourceText([
+      <py.CallSignature
+        parameters={[{ name: "a" }, { name: "b" }]}
+        staticFunction
+      />,
+    ]);
+    expect(result).toRenderTo(d`
+      (a, b)
+    `);
+  });
   it("throws an error for a call signature that's instance and class function at the same time", () => {
     expect(() =>
       toSourceText([
@@ -172,7 +183,7 @@ describe("Call Signature", () => {
           classFunction
         />,
       ]),
-    ).toThrowError(/Cannot be both an instance function and a class function/);
+    ).toThrowError(/A function can only be one of instance, class, or static/);
   });
   it("renders a simple call signature with all properties", () => {
     const result = toSourceText([

--- a/packages/python/test/classdeclarations.test.tsx
+++ b/packages/python/test/classdeclarations.test.tsx
@@ -265,9 +265,8 @@ describe("Python Class - VariableDeclaration", () => {
               initializer={42}
               instanceVariable
             />
-            <py.FunctionDeclaration
+            <py.MethodDeclaration
               name="instanceMethod"
-              instanceFunction
               refkey={classMethodRk}
               returnType={{ children: "int" }}
             />
@@ -316,18 +315,17 @@ describe("Python Class - FunctionDeclaration", () => {
               type={{ children: "int" }}
               instanceVariable
             />
-            <py.FunctionDeclaration
+            <py.MethodDeclaration
               name="my_method"
               parameters={[
                 { name: "a", type: { children: "int" } },
                 { name: "b", type: { children: "int" } },
               ]}
               returnType={{ children: "int" }}
-              instanceFunction
               refkey={methodRefkey}
             >
               return a + b
-            </py.FunctionDeclaration>
+            </py.MethodDeclaration>
             <py.FunctionDeclaration
               name="my_class_method"
               classFunction

--- a/packages/python/test/externals.test.tsx
+++ b/packages/python/test/externals.test.tsx
@@ -118,11 +118,10 @@ it("uses import from external library in multiple class methods", () => {
           instanceVariable
           refkey={refkey("some_var")}
         />
-        <py.FunctionDeclaration
+        <py.MethodDeclaration
           name={"getUser"}
           parameters={[{ name: "userId", type: { children: "int" } }]}
           returnType={{ children: py.requestsModule["models"]["Response"] }}
-          instanceFunction
         >
           <py.StatementList>
             <py.VariableDeclaration
@@ -138,12 +137,11 @@ it("uses import from external library in multiple class methods", () => {
               return response.json()
             `}
           </py.StatementList>
-        </py.FunctionDeclaration>
-        <py.FunctionDeclaration
+        </py.MethodDeclaration>
+        <py.MethodDeclaration
           name={"createUser"}
           parameters={[{ name: "userName", type: { children: "string" } }]}
           returnType={{ children: py.requestsModule["models"]["Response"] }}
-          instanceFunction
         >
           <py.StatementList>
             <py.VariableDeclaration
@@ -159,7 +157,7 @@ it("uses import from external library in multiple class methods", () => {
               return response.json()
             `}
           </py.StatementList>
-        </py.FunctionDeclaration>
+        </py.MethodDeclaration>
       </py.StatementList>
     </py.ClassDeclaration>,
   ];

--- a/packages/python/test/functiondeclaration.test.tsx
+++ b/packages/python/test/functiondeclaration.test.tsx
@@ -65,9 +65,7 @@ describe("Function Declaration", () => {
   it("renders an instance function with a body", () => {
     const result = toSourceText([
       <py.ClassDeclaration name="MyClass">
-        <py.FunctionDeclaration name="bar" instanceFunction={true}>
-          print('hi')
-        </py.FunctionDeclaration>
+        <py.MethodDeclaration name="bar">print('hi')</py.MethodDeclaration>
       </py.ClassDeclaration>,
     ]);
     expect(result).toRenderTo(d`
@@ -108,7 +106,10 @@ describe("Function Declaration", () => {
   it("renders an __init__ function with no body as 'pass'", () => {
     const result = toSourceText([
       <py.ClassDeclaration name="MyClass">
-        <py.InitFunctionDeclaration parameters={[{ name: "x" }]} />
+        <py.DunderMethodDeclaration
+          name="__init__"
+          parameters={[{ name: "x" }]}
+        />
       </py.ClassDeclaration>,
     ]);
     expect(result).toRenderTo(d`
@@ -222,17 +223,13 @@ describe("Function Declaration", () => {
 
     `);
   });
-  it("renders function with parameters", () => {
+  it("renders method with parameters", () => {
     const parameters = [{ name: "x", type: { children: "int" } }];
     const decl = (
       <py.ClassDeclaration name="MyClass">
-        <py.FunctionDeclaration
-          name="foo"
-          instanceFunction
-          parameters={parameters}
-        >
+        <py.MethodDeclaration name="foo" parameters={parameters}>
           self.attribute = "value"
-        </py.FunctionDeclaration>
+        </py.MethodDeclaration>
       </py.ClassDeclaration>
     );
 
@@ -244,13 +241,51 @@ describe("Function Declaration", () => {
 
     `);
   });
+  it("renders class method with parameters", () => {
+    const parameters = [{ name: "x", type: { children: "int" } }];
+    const decl = (
+      <py.ClassDeclaration name="MyClass">
+        <py.ClassMethodDeclaration name="foo" parameters={parameters}>
+          self.attribute = "value"
+        </py.ClassMethodDeclaration>
+      </py.ClassDeclaration>
+    );
+
+    expect(toSourceText([decl])).toBe(d`
+      class MyClass:
+          @classmethod
+          def foo(cls, x: int):
+              self.attribute = "value"
+
+
+    `);
+  });
+  it("renders static method with parameters", () => {
+    const parameters = [{ name: "x", type: { children: "int" } }];
+    const decl = (
+      <py.ClassDeclaration name="MyClass">
+        <py.StaticMethodDeclaration name="foo" parameters={parameters}>
+          attribute = "value"
+        </py.StaticMethodDeclaration>
+      </py.ClassDeclaration>
+    );
+
+    expect(toSourceText([decl])).toBe(d`
+      class MyClass:
+          @staticmethod
+          def foo(x: int):
+              attribute = "value"
+
+
+    `);
+  });
   it("renders __init__ function with parameters", () => {
     const parameters = [{ name: "x", type: { children: "int" } }];
     const decl = (
       <py.ClassDeclaration name="MyClass">
-        <py.InitFunctionDeclaration parameters={parameters}>
+        <py.DunderMethodDeclaration name="__init__" parameters={parameters}>
           self.attribute = "value"
-        </py.InitFunctionDeclaration>
+        </py.DunderMethodDeclaration>
       </py.ClassDeclaration>
     );
 

--- a/samples/python-example/src/components/ClientMethod.tsx
+++ b/samples/python-example/src/components/ClientMethod.tsx
@@ -100,11 +100,10 @@ export function ClientMethod(props: ClientMethodProps) {
   );
 
   return (
-    <py.FunctionDeclaration
+    <py.MethodDeclaration
       name={op.name}
       parameters={parameters}
       returnType={responseReturnType}
-      instanceFunction={true}
       doc={functionDoc}
       refkey={refkey(op.name)}
     >
@@ -114,6 +113,6 @@ export function ClientMethod(props: ClientMethodProps) {
           return ${returnCode}
         `}
       </py.StatementList>
-    </py.FunctionDeclaration>
+    </py.MethodDeclaration>
   );
 }


### PR DESCRIPTION
Refactor FunctionDeclaration to more properly represent each scenario:
- `FunctionDeclaration`: Standalone function
- `MethodDeclaration`: Normal method
- `ClassMethodDeclaration`: Class method, prepended with `@classmethod`
- `StaticMethodDeclaration`: Static method, prepended with `@staticmethod`
- `DunderMethodDeclaration`: Any dunder method. Any formatting to the name that would normally happen will be skipped.