### PR TITLE
Splits docs components into separate components

### DIFF
--- a/packages/python/src/components/PyDoc.tsx
+++ b/packages/python/src/components/PyDoc.tsx
@@ -4,6 +4,700 @@ import { ParameterDescriptor } from "../parameter-descriptor.js";
 import { resolveTypeExpression } from "../utils.js";
 import { Atom, type TypeExpressionProps } from "./index.js";
 
+export interface FunctionDocProps {
+  description: Children[];
+  parameters?: ParameterDescriptor[];
+  returns?: string;
+  yields?: string;
+  raises?: string[];
+  note?: string;
+  style?: "google";
+}
+
+/**
+ * A component that creates a FunctionDoc block for functions.
+ */
+export function FunctionDoc(props: FunctionDocProps) {
+  const style = props.style ?? "google";
+  if (style === "google") {
+    return (
+      <GoogleStyleFunctionDoc
+        description={props.description}
+        parameters={props.parameters}
+        returns={props.returns}
+        yields={props.yields}
+        raises={props.raises}
+        note={props.note}
+      />
+    );
+  }
+}
+
+export interface ClassDocProps {
+  description: Children[];
+  parameters?: ParameterDescriptor[];
+  attributes?: GoogleStyleDocAttributeProps[];
+  note?: string;
+  style?: "google";
+}
+
+/**
+ * A component that creates a ClassDoc block for classes.
+ */
+export function ClassDoc(props: ClassDocProps) {
+  const style = props.style ?? "google";
+  if (style === "google") {
+    return (
+      <GoogleStyleClassDoc
+        description={props.description}
+        parameters={props.parameters}
+        attributes={props.attributes}
+        note={props.note}
+      />
+    );
+  }
+}
+
+export interface ModuleDocProps {
+  description: Children[];
+  attributes?: GoogleStyleDocAttributeProps[];
+  todo?: string[];
+  style?: "google";
+}
+
+/**
+ * A component that creates a ModuleDoc block for module-level documentation.
+ */
+export function ModuleDoc(props: ModuleDocProps) {
+  const style = props.style ?? "google";
+  if (style === "google") {
+    return (
+      <GoogleStyleModuleDoc
+        description={props.description}
+        attributes={props.attributes}
+        todo={props.todo}
+      />
+    );
+  }
+}
+
+export interface PropertyDocProps {
+  description: Children[];
+  returns?: string;
+  note?: string;
+  style?: "google";
+}
+
+/**
+ * A component that creates a PropertyDoc block for `@property` decorated methods.
+ */
+export function PropertyDoc(props: PropertyDocProps) {
+  const style = props.style ?? "google";
+  if (style === "google") {
+    return (
+      <GoogleStylePropertyDoc
+        description={props.description}
+        returns={props.returns}
+        note={props.note}
+      />
+    );
+  }
+}
+
+export interface GeneratorDocProps {
+  description: Children[];
+  parameters?: ParameterDescriptor[];
+  yields?: string;
+  raises?: string[];
+  note?: string;
+  style?: "google";
+}
+
+/**
+ * A component that creates a GeneratorDoc block for generator functions.
+ */
+export function GeneratorDoc(props: GeneratorDocProps) {
+  const style = props.style ?? "google";
+  if (style === "google") {
+    return (
+      <GoogleStyleGeneratorDoc
+        description={props.description}
+        parameters={props.parameters}
+        yields={props.yields}
+        raises={props.raises}
+        note={props.note}
+      />
+    );
+  }
+}
+
+export interface ExceptionDocProps {
+  description: Children[];
+  parameters?: ParameterDescriptor[];
+  attributes?: GoogleStyleDocAttributeProps[];
+  note?: string;
+  style?: "google";
+}
+
+/**
+ * A component that creates an ExceptionDoc block for custom exception classes.
+ */
+export function ExceptionDoc(props: ExceptionDocProps) {
+  const style = props.style ?? "google";
+  if (style === "google") {
+    return (
+      <GoogleStyleExceptionDoc
+        description={props.description}
+        parameters={props.parameters}
+        attributes={props.attributes}
+        note={props.note}
+      />
+    );
+  }
+}
+
+export interface AttributeDocProps {
+  name: Children;
+  type?: TypeExpressionProps;
+  children?: Children;
+  style?: "google";
+}
+
+/**
+ * A component that creates documentation for a single attribute.
+ * This can be used for both inline and block attribute documentation.
+ */
+export function AttributeDoc(props: AttributeDocProps) {
+  const style = props.style ?? "google";
+  if (style === "google") {
+    return (
+      <GoogleStyleAttributeDoc name={props.name} type={props.type}>
+        {props.children}
+      </GoogleStyleAttributeDoc>
+    );
+  }
+}
+
+export interface MethodDocProps {
+  description: Children[];
+  parameters?: ParameterDescriptor[];
+  returns?: string;
+  raises?: string[];
+  note?: string;
+  style?: "google";
+}
+
+/**
+ * A component that creates a MethodDoc block for class methods.
+ * Automatically adds a note about not including 'self' parameter if no custom note is provided.
+ */
+export function MethodDoc(props: MethodDocProps) {
+  const style = props.style ?? "google";
+  if (style === "google") {
+    const defaultNote =
+      "Do not include the 'self' parameter in the Args section.";
+    return (
+      <GoogleStyleMethodDoc
+        description={props.description}
+        parameters={props.parameters}
+        returns={props.returns}
+        raises={props.raises}
+        note={props.note ?? defaultNote}
+      />
+    );
+  }
+}
+
+export interface PyDocProps {
+  children: Children;
+}
+
+/**
+ * A PyDoc comment. The children of this component are joined with two hard
+ * linebreaks. This is useful for creating PyDoc comments with multiple paragraphs.
+ */
+export function PyDoc(props: PyDocProps) {
+  const children = childrenArray(() => props.children);
+  return (
+    <>
+      {'"""'}
+      <hbr />
+      <List doubleHardline>{children}</List>
+      <hbr />
+      {'"""'}
+      <hbr />
+    </>
+  );
+}
+
+export interface PyDocExampleProps {
+  children: Children;
+}
+
+/**
+ * Create a PyDoc example, which is prepended by \>\>.
+ */
+export function PyDocExample(props: PyDocExampleProps) {
+  const children = childrenArray(() => props.children);
+  let lines: string[] = [];
+
+  if (children.length === 1 && typeof children[0] === "string") {
+    // Split, trim each line, and filter out empty lines
+    lines = children[0]
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter((line) => line.length > 0);
+  } else {
+    // For non-string children, filter out empty/whitespace-only strings
+    lines = children
+      .map((child) => (typeof child === "string" ? child : ""))
+      .map((line) => line.trim())
+      .filter((line) => line.length > 0);
+  }
+
+  return (
+    <>
+      <For each={lines}>
+        {(line) => (
+          <>
+            {">> "}
+            {line}
+          </>
+        )}
+      </For>
+    </>
+  );
+}
+
+export interface SimpleCommentBlockProps {
+  children: Children;
+}
+
+export function SimpleCommentBlock(props: SimpleCommentBlockProps) {
+  return (
+    <>
+      #{" "}
+      <align string="# ">
+        <Prose>{props.children}</Prose>
+      </align>
+    </>
+  );
+}
+
+export interface SimpleInlineCommentProps {
+  children: Children;
+}
+
+export function SimpleInlineComment(props: SimpleInlineCommentProps) {
+  return (
+    <>
+      {"  "}# <Prose>{props.children}</Prose>
+    </>
+  );
+}
+
+export interface SimpleInlineCommentProps {
+  children: Children;
+}
+
+export function SimpleInlineMemberComment(props: SimpleInlineCommentProps) {
+  return (
+    <>
+      {"  "}#: <Prose>{props.children}</Prose>
+    </>
+  );
+}
+
+interface GoogleStyleFunctionDocProps extends Omit<FunctionDocProps, "style"> {}
+
+/**
+ * A component that creates a GoogleStyleFunctionDoc block for functions.
+ */
+function GoogleStyleFunctionDoc(props: GoogleStyleFunctionDocProps) {
+  // We are creating a list instead of relying on <Show> because otherwise
+  // <List> would render spaces between the elements even if <Show> evaluates to false.
+  const children = [];
+  if (props.description !== undefined) {
+    children.push(
+      <List doubleHardline>{props.description.map((param) => param)}</List>,
+    );
+  }
+  if (props.parameters !== undefined && props.parameters.length > 0) {
+    children.push(<GoogleStyleDocParams parameters={props.parameters} />);
+  }
+  if (props.returns !== undefined) {
+    children.push(<GoogleStyleDocReturn message={props.returns} />);
+  }
+  if (props.yields !== undefined) {
+    children.push(<GoogleStyleDocYields message={props.yields} />);
+  }
+  if (props.raises !== undefined && props.raises.length > 0) {
+    children.push(
+      props.raises!.map((param) => <GoogleStyleDocRaises message={param} />),
+    );
+  }
+  if (props.note !== undefined) {
+    children.push(<GoogleStyleDocNote message={props.note} />);
+  }
+  return <PyDoc>{children}</PyDoc>;
+}
+
+interface GoogleStyleClassDocProps extends Omit<ClassDocProps, "style"> {}
+
+/**
+ * A component that creates a GoogleStyleClassDoc block for classes.
+ */
+function GoogleStyleClassDoc(props: GoogleStyleClassDocProps) {
+  // We are creating a list instead of relying on <Show> because otherwise
+  // <List> would render spaces between the elements even if <Show> evaluates to false.
+  const children = [];
+  if (props.description !== undefined) {
+    children.push(
+      <List doubleHardline>{props.description.map((param) => param)}</List>,
+    );
+  }
+  if (props.attributes !== undefined && props.attributes.length > 0) {
+    children.push(<GoogleStyleDocAttributes attributes={props.attributes} />);
+  }
+  if (props.parameters !== undefined && props.parameters.length > 0) {
+    children.push(<GoogleStyleDocParams parameters={props.parameters} />);
+  }
+  if (props.note !== undefined) {
+    children.push(<GoogleStyleDocNote message={props.note} />);
+  }
+  return <PyDoc>{children}</PyDoc>;
+}
+
+interface GoogleStyleModuleDocProps extends Omit<ModuleDocProps, "style"> {}
+
+/**
+ * A component that creates a GoogleStyleModuleDoc block for modules.
+ */
+function GoogleStyleModuleDoc(props: GoogleStyleModuleDocProps) {
+  const children = [];
+  if (props.description !== undefined) {
+    children.push(
+      <List doubleHardline>{props.description.map((param) => param)}</List>,
+    );
+  }
+  if (props.attributes !== undefined && props.attributes.length > 0) {
+    children.push(<GoogleStyleDocAttributes attributes={props.attributes} />);
+  }
+  if (props.todo !== undefined && props.todo.length > 0) {
+    children.push(<GoogleStyleDocTodo items={props.todo} />);
+  }
+  return <PyDoc>{children}</PyDoc>;
+}
+
+interface GoogleStylePropertyDocProps extends Omit<PropertyDocProps, "style"> {}
+
+/**
+ * A component that creates a GoogleStylePropertyDoc block for properties.
+ */
+function GoogleStylePropertyDoc(props: GoogleStylePropertyDocProps) {
+  const children = [];
+  if (props.description !== undefined) {
+    children.push(
+      <List doubleHardline>{props.description.map((param) => param)}</List>,
+    );
+  }
+  if (props.returns !== undefined) {
+    children.push(<GoogleStyleDocReturn message={props.returns} />);
+  }
+  if (props.note !== undefined) {
+    children.push(<GoogleStyleDocNote message={props.note} />);
+  }
+  return <PyDoc>{children}</PyDoc>;
+}
+
+interface GoogleStyleGeneratorDocProps
+  extends Omit<GeneratorDocProps, "style"> {}
+
+/**
+ * A component that creates a GoogleStyleGeneratorDoc block for generators.
+ */
+function GoogleStyleGeneratorDoc(props: GoogleStyleGeneratorDocProps) {
+  const children = [];
+  if (props.description !== undefined) {
+    children.push(
+      <List doubleHardline>{props.description.map((param) => param)}</List>,
+    );
+  }
+  if (props.parameters !== undefined && props.parameters.length > 0) {
+    children.push(<GoogleStyleDocParams parameters={props.parameters} />);
+  }
+  if (props.yields !== undefined) {
+    children.push(<GoogleStyleDocYields message={props.yields} />);
+  }
+  if (props.raises !== undefined && props.raises.length > 0) {
+    children.push(
+      props.raises!.map((param) => <GoogleStyleDocRaises message={param} />),
+    );
+  }
+  if (props.note !== undefined) {
+    children.push(<GoogleStyleDocNote message={props.note} />);
+  }
+  return <PyDoc>{children}</PyDoc>;
+}
+
+interface GoogleStyleExceptionDocProps
+  extends Omit<ExceptionDocProps, "style"> {}
+
+/**
+ * A component that creates a GoogleStyleExceptionDoc block for exceptions.
+ */
+function GoogleStyleExceptionDoc(props: GoogleStyleExceptionDocProps) {
+  const children = [];
+  if (props.description !== undefined) {
+    children.push(
+      <List doubleHardline>{props.description.map((param) => param)}</List>,
+    );
+  }
+  if (props.parameters !== undefined && props.parameters.length > 0) {
+    children.push(<GoogleStyleDocParams parameters={props.parameters} />);
+  }
+  if (props.attributes !== undefined && props.attributes.length > 0) {
+    children.push(<GoogleStyleDocAttributes attributes={props.attributes} />);
+  }
+  if (props.note !== undefined) {
+    children.push(<GoogleStyleDocNote message={props.note} />);
+  }
+  return <PyDoc>{children}</PyDoc>;
+}
+
+interface GoogleStyleAttributeDocProps
+  extends Omit<AttributeDocProps, "style"> {}
+
+/**
+ * A component that creates a GoogleStyleAttributeDoc block for attributes.
+ */
+function GoogleStyleAttributeDoc(props: GoogleStyleAttributeDocProps) {
+  return (
+    <GoogleStyleDocAttribute name={props.name} type={props.type}>
+      {props.children}
+    </GoogleStyleDocAttribute>
+  );
+}
+
+interface GoogleStyleMethodDocProps extends Omit<MethodDocProps, "style"> {}
+
+/**
+ * A component that creates a GoogleStyleMethodDoc block for methods.
+ */
+function GoogleStyleMethodDoc(props: GoogleStyleMethodDocProps) {
+  const children = [];
+  if (props.description !== undefined) {
+    children.push(
+      <List doubleHardline>{props.description.map((param) => param)}</List>,
+    );
+  }
+  if (props.parameters !== undefined && props.parameters.length > 0) {
+    children.push(<GoogleStyleDocParams parameters={props.parameters} />);
+  }
+  if (props.returns !== undefined) {
+    children.push(<GoogleStyleDocReturn message={props.returns} />);
+  }
+  if (props.raises !== undefined && props.raises.length > 0) {
+    children.push(
+      props.raises!.map((param) => <GoogleStyleDocRaises message={param} />),
+    );
+  }
+  if (props.note !== undefined) {
+    children.push(<GoogleStyleDocNote message={props.note} />);
+  }
+  return <PyDoc>{children}</PyDoc>;
+}
+
+interface GoogleStyleDocParamsProps {
+  parameters: ParameterDescriptor[];
+}
+
+/**
+ * A component that creates a GoogleStyleDoc block for parameters.
+ */
+function GoogleStyleDocParams(props: GoogleStyleDocParamsProps) {
+  const parameters = props.parameters;
+
+  // Don't render anything if there are no parameters
+  if (!parameters || parameters.length === 0) {
+    return null;
+  }
+
+  return (
+    <>
+      {"Args:"}
+      <Indent>
+        <List doubleHardline>
+          {parameters.map((param) => (
+            <GoogleStyleDocParam
+              name={param.name}
+              type={param.type}
+              default={param.default}
+            >
+              {param.doc}
+            </GoogleStyleDocParam>
+          ))}
+        </List>
+      </Indent>
+    </>
+  );
+}
+
+interface GoogleStyleDocParamProps {
+  name: Children;
+  type?: TypeExpressionProps;
+  children?: Children;
+  default?: Children;
+}
+
+/**
+ * Create a GoogleStyleDoc parameter.
+ */
+function GoogleStyleDocParam(props: GoogleStyleDocParamProps) {
+  return (
+    <>
+      <GoogleStyleDocParamName name={props.name} />
+      <GoogleStyleDocParamType
+        type={props.type}
+        default={Boolean(props.default)}
+      />
+      <GoogleStyleDocParamDescription
+        children={props.children}
+        default={props.default}
+      />
+    </>
+  );
+}
+
+interface GoogleStyleDocReturnProps {
+  message: string;
+}
+
+/**
+ * A component that creates a GoogleStyleDoc block for parameters.
+ */
+function GoogleStyleDocReturn(props: GoogleStyleDocReturnProps) {
+  return (
+    <>
+      {"Returns:"}
+      <Indent>{props.message}</Indent>
+    </>
+  );
+}
+
+interface GoogleStyleDocRaisesProps {
+  message: string;
+}
+
+/**
+ * A component that creates a GoogleStyleDoc block for exceptions.
+ */
+function GoogleStyleDocRaises(props: GoogleStyleDocRaisesProps) {
+  return (
+    <>
+      {"Raises:"}
+      <Indent>{props.message}</Indent>
+    </>
+  );
+}
+
+interface GoogleStyleDocYieldsProps {
+  message: string;
+}
+
+/**
+ * A component that creates a GoogleStyleDoc block for generator yields.
+ */
+function GoogleStyleDocYields(props: GoogleStyleDocYieldsProps) {
+  return (
+    <>
+      {"Yields:"}
+      <Indent>{props.message}</Indent>
+    </>
+  );
+}
+
+export interface GoogleStyleDocAttributeProps {
+  name: Children;
+  type?: TypeExpressionProps;
+  children?: Children;
+}
+
+/**
+ * Create a GoogleStyleDoc attribute entry.
+ */
+function GoogleStyleDocAttribute(props: GoogleStyleDocAttributeProps) {
+  return (
+    <>
+      <GoogleStyleDocParamName name={props.name} />
+      <GoogleStyleDocParamType type={props.type} />
+      <GoogleStyleDocParamDescription children={props.children} />
+    </>
+  );
+}
+
+interface GoogleStyleDocAttributesProps {
+  attributes: GoogleStyleDocAttributeProps[];
+}
+
+/**
+ * A component that creates a GoogleStyleDoc block for attributes.
+ */
+function GoogleStyleDocAttributes(props: GoogleStyleDocAttributesProps) {
+  return (
+    <>
+      {"Attributes:"}
+      <Indent>
+        <List doubleHardline>
+          {props.attributes.map((attr) => (
+            <GoogleStyleDocAttribute name={attr.name} type={attr.type}>
+              {attr.children}
+            </GoogleStyleDocAttribute>
+          ))}
+        </List>
+      </Indent>
+    </>
+  );
+}
+
+interface GoogleStyleDocNoteProps {
+  message: string;
+}
+
+/**
+ * A component that creates a GoogleStyleDoc block for notes.
+ */
+function GoogleStyleDocNote(props: GoogleStyleDocNoteProps) {
+  return (
+    <>
+      {"Note:"}
+      <Indent>{props.message}</Indent>
+    </>
+  );
+}
+
+interface GoogleStyleDocTodoProps {
+  items: string[];
+}
+
+/**
+ * A component that creates a GoogleStyleDoc block for todo items.
+ */
+function GoogleStyleDocTodo(props: GoogleStyleDocTodoProps) {
+  return (
+    <>
+      {"Todo:"}
+      <Indent>
+        <List hardline>
+          {props.items.map((item) => (
+            <>* {item}</>
+          ))}
+        </List>
+      </Indent>
+    </>
+  );
+}
+
 interface GoogleStyleDocParamTypeProps {
   type?: TypeExpressionProps;
   default?: boolean;
@@ -53,298 +747,5 @@ function GoogleStyleDocParamDescription(
         </Prose>
       </align>
     </Show>
-  );
-}
-
-export interface GoogleStyleDocParamProps {
-  name: Children;
-  type?: TypeExpressionProps;
-  children?: Children;
-  default?: Children;
-}
-
-/**
- * Create a GoogleStyleDoc parameter.
- */
-export function GoogleStyleDocParam(props: GoogleStyleDocParamProps) {
-  return (
-    <>
-      <GoogleStyleDocParamName name={props.name} />
-      <GoogleStyleDocParamType
-        type={props.type}
-        default={Boolean(props.default)}
-      />
-      <GoogleStyleDocParamDescription
-        children={props.children}
-        default={props.default}
-      />
-    </>
-  );
-}
-
-export interface GoogleStyleDocParamsProps {
-  parameters: ParameterDescriptor[] | string[];
-}
-
-/**
- * A component that creates a GoogleStyleDoc block for parameters.
- */
-export function GoogleStyleDocParams(props: GoogleStyleDocParamsProps) {
-  const parameters = normalizeParametersForDoc(props.parameters);
-  return (
-    <>
-      {"Args:"}
-      <Indent>
-        <List doubleHardline>
-          {parameters.map((param) => (
-            <GoogleStyleDocParam
-              name={param.name}
-              type={param.type}
-              default={param.default}
-            >
-              {param.doc}
-            </GoogleStyleDocParam>
-          ))}
-        </List>
-      </Indent>
-    </>
-  );
-}
-
-export interface GoogleStyleDocReturnProps {
-  message: string;
-}
-
-/**
- * A component that creates a GoogleStyleDoc block for parameters.
- */
-export function GoogleStyleDocReturn(props: GoogleStyleDocReturnProps) {
-  return (
-    <>
-      {"Returns:"}
-      <Indent>{props.message}</Indent>
-    </>
-  );
-}
-
-export interface GoogleStyleDocRaisesProps {
-  message: string;
-}
-
-/**
- * A component that creates a GoogleStyleDoc block for parameters.
- */
-export function GoogleStyleDocRaises(props: GoogleStyleDocRaisesProps) {
-  return (
-    <>
-      {"Raises:"}
-      <Indent>{props.message}</Indent>
-    </>
-  );
-}
-
-export interface GoogleStyleFunctionDocProps
-  extends Omit<FunctionDocProps, "style"> {}
-
-/**
- * A component that creates a GoogleStyleFunctionDoc block for parameters.
- */
-export function GoogleStyleFunctionDoc(props: GoogleStyleFunctionDocProps) {
-  // We are creating a list instead of relying on <Show> because otherwise
-  // <List> would render spaces between the elements even if <Show> evaluates to false.
-  const children = [];
-  if (props.description !== undefined) {
-    children.push(
-      <List doubleHardline>{props.description.map((param) => param)}</List>,
-    );
-  }
-  if (props.parameters !== undefined && props.parameters.length > 0) {
-    children.push(<GoogleStyleDocParams parameters={props.parameters} />);
-  }
-  if (props.returns !== undefined) {
-    children.push(<GoogleStyleDocReturn message={props.returns} />);
-  }
-  if (props.raises !== undefined && props.raises.length > 0) {
-    children.push(
-      props.raises!.map((param) => <GoogleStyleDocRaises message={param} />),
-    );
-  }
-  return <PyDoc>{children}</PyDoc>;
-}
-
-export interface FunctionDocProps {
-  description: Children[];
-  parameters?: ParameterDescriptor[] | string[];
-  returns?: string;
-  raises?: string[];
-  style?: "google";
-}
-
-/**
- * A component that creates a FunctionDoc block for parameters.
- */
-export function FunctionDoc(props: FunctionDocProps) {
-  const style = props.style ?? "google";
-  if (style === "google") {
-    return (
-      <GoogleStyleFunctionDoc
-        description={props.description}
-        parameters={props.parameters}
-        returns={props.returns}
-        raises={props.raises}
-      />
-    );
-  }
-}
-
-export interface ClassDocProps {
-  description: Children[];
-  parameters?: ParameterDescriptor[] | string[];
-  style?: "google";
-}
-
-/**
- * A component that creates a ClassDoc block for parameters.
- */
-export function ClassDoc(props: ClassDocProps) {
-  const style = props.style ?? "google";
-  if (style === "google") {
-    return (
-      <GoogleStyleClassDoc
-        description={props.description}
-        parameters={props.parameters}
-      />
-    );
-  }
-}
-
-export interface GoogleStyleClassDocProps
-  extends Omit<ClassDocProps, "style"> {}
-
-/**
- * A component that creates a GoogleStyleClassDoc block for parameters.
- */
-export function GoogleStyleClassDoc(props: GoogleStyleClassDocProps) {
-  // We are creating a list instead of relying on <Show> because otherwise
-  // <List> would render spaces between the elements even if <Show> evaluates to false.
-  const children = [];
-  if (props.description !== undefined) {
-    children.push(
-      <List doubleHardline>{props.description.map((param) => param)}</List>,
-    );
-  }
-  if (props.parameters !== undefined && props.parameters.length > 0) {
-    children.push(<GoogleStyleDocParams parameters={props.parameters} />);
-  }
-  return <PyDoc>{children}</PyDoc>;
-}
-
-export interface PyDocExampleProps {
-  children: Children;
-}
-
-/**
- * Create a PyDoc example, which is prepended by \>\>.
- */
-export function PyDocExample(props: PyDocExampleProps) {
-  const children = childrenArray(() => props.children);
-  let lines: string[] = [];
-
-  if (children.length === 1 && typeof children[0] === "string") {
-    // Split, trim each line, and filter out empty lines
-    lines = children[0]
-      .split(/\r?\n/)
-      .map((line) => line.trim())
-      .filter((line) => line.length > 0);
-  } else {
-    // For non-string children, filter out empty/whitespace-only strings
-    lines = children
-      .map((child) => (typeof child === "string" ? child : ""))
-      .map((line) => line.trim())
-      .filter((line) => line.length > 0);
-  }
-
-  return (
-    <>
-      <For each={lines}>
-        {(line) => (
-          <>
-            {">> "}
-            {line}
-          </>
-        )}
-      </For>
-    </>
-  );
-}
-
-function normalizeParametersForDoc(
-  parameters: ParameterDescriptor[] | string[],
-): ParameterDescriptor[] {
-  if (parameters.some((p) => typeof p === "string")) {
-    return [];
-  }
-
-  return parameters as ParameterDescriptor[];
-}
-
-export interface PyDocProps {
-  children: Children;
-}
-
-/**
- * A PyDoc comment. The children of this component are joined with two hard
- * linebreaks. This is useful for creating PyDoc comments with multiple paragraphs.
- */
-export function PyDoc(props: PyDocProps) {
-  const children = childrenArray(() => props.children);
-  return (
-    <>
-      {'"""'}
-      <hbr />
-      <List doubleHardline>{children}</List>
-      <hbr />
-      {'"""'}
-      <hbr />
-    </>
-  );
-}
-
-export interface SimpleCommentBlockProps {
-  children: Children;
-}
-
-export function SimpleCommentBlock(props: SimpleCommentBlockProps) {
-  return (
-    <>
-      #{" "}
-      <align string="# ">
-        <Prose>{props.children}</Prose>
-      </align>
-    </>
-  );
-}
-
-export interface SimpleInlineCommentProps {
-  children: Children;
-}
-
-export function SimpleInlineComment(props: SimpleInlineCommentProps) {
-  return (
-    <>
-      {"  "}# <Prose>{props.children}</Prose>
-    </>
-  );
-}
-
-export interface SimpleInlineCommentProps {
-  children: Children;
-}
-
-export function SimpleInlineMemberComment(props: SimpleInlineCommentProps) {
-  return (
-    <>
-      {"  "}#: <Prose>{props.children}</Prose>
-    </>
   );
 }

--- a/packages/python/src/components/PyDoc.tsx
+++ b/packages/python/src/components/PyDoc.tsx
@@ -10,6 +10,10 @@ export interface FunctionDocProps {
   returns?: string;
   yields?: string;
   raises?: string[];
+  examples?: Children[];
+  seeAlso?: string[];
+  warning?: string;
+  deprecated?: string;
   note?: string;
   style?: "google";
 }
@@ -19,17 +23,14 @@ export interface FunctionDocProps {
  */
 export function FunctionDoc(props: FunctionDocProps) {
   const style = props.style ?? "google";
-  if (style === "google") {
-    return (
-      <GoogleStyleFunctionDoc
-        description={props.description}
-        parameters={props.parameters}
-        returns={props.returns}
-        yields={props.yields}
-        raises={props.raises}
-        note={props.note}
-      />
-    );
+  const { style: _style, ...rest } = props;
+  switch (style) {
+    case "google":
+      return (
+        <GoogleStyleFunctionDoc {...(rest as GoogleStyleFunctionDocProps)} />
+      );
+    default:
+      return undefined;
   }
 }
 
@@ -37,6 +38,10 @@ export interface ClassDocProps {
   description: Children[];
   parameters?: ParameterDescriptor[];
   attributes?: GoogleStyleDocAttributeProps[];
+  examples?: Children[];
+  seeAlso?: string[];
+  warning?: string;
+  deprecated?: string;
   note?: string;
   style?: "google";
 }
@@ -46,21 +51,22 @@ export interface ClassDocProps {
  */
 export function ClassDoc(props: ClassDocProps) {
   const style = props.style ?? "google";
-  if (style === "google") {
-    return (
-      <GoogleStyleClassDoc
-        description={props.description}
-        parameters={props.parameters}
-        attributes={props.attributes}
-        note={props.note}
-      />
-    );
+  const { style: _style, ...rest } = props;
+  switch (style) {
+    case "google":
+      return <GoogleStyleClassDoc {...(rest as GoogleStyleClassDocProps)} />;
+    default:
+      return undefined;
   }
 }
 
 export interface ModuleDocProps {
   description: Children[];
   attributes?: GoogleStyleDocAttributeProps[];
+  examples?: Children[];
+  seeAlso?: string[];
+  warning?: string;
+  deprecated?: string;
   todo?: string[];
   style?: "google";
 }
@@ -70,20 +76,22 @@ export interface ModuleDocProps {
  */
 export function ModuleDoc(props: ModuleDocProps) {
   const style = props.style ?? "google";
-  if (style === "google") {
-    return (
-      <GoogleStyleModuleDoc
-        description={props.description}
-        attributes={props.attributes}
-        todo={props.todo}
-      />
-    );
+  const { style: _style, ...rest } = props;
+  switch (style) {
+    case "google":
+      return <GoogleStyleModuleDoc {...(rest as GoogleStyleModuleDocProps)} />;
+    default:
+      return undefined;
   }
 }
 
 export interface PropertyDocProps {
   description: Children[];
   returns?: string;
+  examples?: Children[];
+  seeAlso?: string[];
+  warning?: string;
+  deprecated?: string;
   note?: string;
   style?: "google";
 }
@@ -93,14 +101,14 @@ export interface PropertyDocProps {
  */
 export function PropertyDoc(props: PropertyDocProps) {
   const style = props.style ?? "google";
-  if (style === "google") {
-    return (
-      <GoogleStylePropertyDoc
-        description={props.description}
-        returns={props.returns}
-        note={props.note}
-      />
-    );
+  const { style: _style, ...rest } = props;
+  switch (style) {
+    case "google":
+      return (
+        <GoogleStylePropertyDoc {...(rest as GoogleStylePropertyDocProps)} />
+      );
+    default:
+      return undefined;
   }
 }
 
@@ -109,6 +117,10 @@ export interface GeneratorDocProps {
   parameters?: ParameterDescriptor[];
   yields?: string;
   raises?: string[];
+  examples?: Children[];
+  seeAlso?: string[];
+  warning?: string;
+  deprecated?: string;
   note?: string;
   style?: "google";
 }
@@ -118,16 +130,14 @@ export interface GeneratorDocProps {
  */
 export function GeneratorDoc(props: GeneratorDocProps) {
   const style = props.style ?? "google";
-  if (style === "google") {
-    return (
-      <GoogleStyleGeneratorDoc
-        description={props.description}
-        parameters={props.parameters}
-        yields={props.yields}
-        raises={props.raises}
-        note={props.note}
-      />
-    );
+  const { style: _style, ...rest } = props;
+  switch (style) {
+    case "google":
+      return (
+        <GoogleStyleGeneratorDoc {...(rest as GoogleStyleGeneratorDocProps)} />
+      );
+    default:
+      return undefined;
   }
 }
 
@@ -135,6 +145,10 @@ export interface ExceptionDocProps {
   description: Children[];
   parameters?: ParameterDescriptor[];
   attributes?: GoogleStyleDocAttributeProps[];
+  examples?: Children[];
+  seeAlso?: string[];
+  warning?: string;
+  deprecated?: string;
   note?: string;
   style?: "google";
 }
@@ -144,15 +158,14 @@ export interface ExceptionDocProps {
  */
 export function ExceptionDoc(props: ExceptionDocProps) {
   const style = props.style ?? "google";
-  if (style === "google") {
-    return (
-      <GoogleStyleExceptionDoc
-        description={props.description}
-        parameters={props.parameters}
-        attributes={props.attributes}
-        note={props.note}
-      />
-    );
+  const { style: _style, ...rest } = props;
+  switch (style) {
+    case "google":
+      return (
+        <GoogleStyleExceptionDoc {...(rest as GoogleStyleExceptionDocProps)} />
+      );
+    default:
+      return undefined;
   }
 }
 
@@ -169,12 +182,14 @@ export interface AttributeDocProps {
  */
 export function AttributeDoc(props: AttributeDocProps) {
   const style = props.style ?? "google";
-  if (style === "google") {
-    return (
-      <GoogleStyleAttributeDoc name={props.name} type={props.type}>
-        {props.children}
-      </GoogleStyleAttributeDoc>
-    );
+  const { style: _style, ...rest } = props;
+  switch (style) {
+    case "google":
+      return (
+        <GoogleStyleAttributeDoc {...(rest as GoogleStyleAttributeDocProps)} />
+      );
+    default:
+      return undefined;
   }
 }
 
@@ -183,7 +198,12 @@ export interface MethodDocProps {
   parameters?: ParameterDescriptor[];
   returns?: string;
   raises?: string[];
+  examples?: Children[];
+  seeAlso?: string[];
+  warning?: string;
+  deprecated?: string;
   note?: string;
+  overrides?: string;
   style?: "google";
 }
 
@@ -193,18 +213,20 @@ export interface MethodDocProps {
  */
 export function MethodDoc(props: MethodDocProps) {
   const style = props.style ?? "google";
-  if (style === "google") {
-    const defaultNote =
-      "Do not include the 'self' parameter in the Args section.";
-    return (
-      <GoogleStyleMethodDoc
-        description={props.description}
-        parameters={props.parameters}
-        returns={props.returns}
-        raises={props.raises}
-        note={props.note ?? defaultNote}
-      />
-    );
+  switch (style) {
+    case "google": {
+      const defaultNote =
+        "Do not include the 'self' parameter in the Args section.";
+      const { style: _style, note, ...rest } = props;
+      return (
+        <GoogleStyleMethodDoc
+          {...(rest as GoogleStyleMethodDocProps)}
+          note={note ?? defaultNote}
+        />
+      );
+    }
+    default:
+      return undefined;
   }
 }
 
@@ -322,21 +344,33 @@ function GoogleStyleFunctionDoc(props: GoogleStyleFunctionDocProps) {
       <List doubleHardline>{props.description.map((param) => param)}</List>,
     );
   }
-  if (props.parameters !== undefined && props.parameters.length > 0) {
+  if (props.parameters?.length) {
     children.push(<GoogleStyleDocParams parameters={props.parameters} />);
   }
-  if (props.returns !== undefined) {
+  if (props.returns) {
     children.push(<GoogleStyleDocReturn message={props.returns} />);
   }
-  if (props.yields !== undefined) {
+  if (props.yields) {
     children.push(<GoogleStyleDocYields message={props.yields} />);
   }
-  if (props.raises !== undefined && props.raises.length > 0) {
+  if (props.raises?.length) {
     children.push(
       props.raises!.map((param) => <GoogleStyleDocRaises message={param} />),
     );
   }
-  if (props.note !== undefined) {
+  if (props.examples?.length) {
+    children.push(<GoogleStyleDocExamples items={props.examples} />);
+  }
+  if (props.seeAlso?.length) {
+    children.push(<GoogleStyleDocSeeAlso items={props.seeAlso} />);
+  }
+  if (props.warning) {
+    children.push(<GoogleStyleDocWarning message={props.warning} />);
+  }
+  if (props.deprecated) {
+    children.push(<GoogleStyleDocDeprecated message={props.deprecated} />);
+  }
+  if (props.note) {
     children.push(<GoogleStyleDocNote message={props.note} />);
   }
   return <PyDoc>{children}</PyDoc>;
@@ -356,13 +390,25 @@ function GoogleStyleClassDoc(props: GoogleStyleClassDocProps) {
       <List doubleHardline>{props.description.map((param) => param)}</List>,
     );
   }
-  if (props.attributes !== undefined && props.attributes.length > 0) {
+  if (props.attributes?.length) {
     children.push(<GoogleStyleDocAttributes attributes={props.attributes} />);
   }
-  if (props.parameters !== undefined && props.parameters.length > 0) {
+  if (props.parameters?.length) {
     children.push(<GoogleStyleDocParams parameters={props.parameters} />);
   }
-  if (props.note !== undefined) {
+  if (props.examples?.length) {
+    children.push(<GoogleStyleDocExamples items={props.examples} />);
+  }
+  if (props.seeAlso?.length) {
+    children.push(<GoogleStyleDocSeeAlso items={props.seeAlso} />);
+  }
+  if (props.warning) {
+    children.push(<GoogleStyleDocWarning message={props.warning} />);
+  }
+  if (props.deprecated) {
+    children.push(<GoogleStyleDocDeprecated message={props.deprecated} />);
+  }
+  if (props.note) {
     children.push(<GoogleStyleDocNote message={props.note} />);
   }
   return <PyDoc>{children}</PyDoc>;
@@ -380,10 +426,22 @@ function GoogleStyleModuleDoc(props: GoogleStyleModuleDocProps) {
       <List doubleHardline>{props.description.map((param) => param)}</List>,
     );
   }
-  if (props.attributes !== undefined && props.attributes.length > 0) {
+  if (props.attributes?.length) {
     children.push(<GoogleStyleDocAttributes attributes={props.attributes} />);
   }
-  if (props.todo !== undefined && props.todo.length > 0) {
+  if (props.examples?.length) {
+    children.push(<GoogleStyleDocExamples items={props.examples} />);
+  }
+  if (props.seeAlso?.length) {
+    children.push(<GoogleStyleDocSeeAlso items={props.seeAlso} />);
+  }
+  if (props.warning) {
+    children.push(<GoogleStyleDocWarning message={props.warning} />);
+  }
+  if (props.deprecated) {
+    children.push(<GoogleStyleDocDeprecated message={props.deprecated} />);
+  }
+  if (props.todo?.length) {
     children.push(<GoogleStyleDocTodo items={props.todo} />);
   }
   return <PyDoc>{children}</PyDoc>;
@@ -401,10 +459,22 @@ function GoogleStylePropertyDoc(props: GoogleStylePropertyDocProps) {
       <List doubleHardline>{props.description.map((param) => param)}</List>,
     );
   }
-  if (props.returns !== undefined) {
+  if (props.returns) {
     children.push(<GoogleStyleDocReturn message={props.returns} />);
   }
-  if (props.note !== undefined) {
+  if (props.examples?.length) {
+    children.push(<GoogleStyleDocExamples items={props.examples} />);
+  }
+  if (props.seeAlso?.length) {
+    children.push(<GoogleStyleDocSeeAlso items={props.seeAlso} />);
+  }
+  if (props.warning) {
+    children.push(<GoogleStyleDocWarning message={props.warning} />);
+  }
+  if (props.deprecated) {
+    children.push(<GoogleStyleDocDeprecated message={props.deprecated} />);
+  }
+  if (props.note) {
     children.push(<GoogleStyleDocNote message={props.note} />);
   }
   return <PyDoc>{children}</PyDoc>;
@@ -423,18 +493,30 @@ function GoogleStyleGeneratorDoc(props: GoogleStyleGeneratorDocProps) {
       <List doubleHardline>{props.description.map((param) => param)}</List>,
     );
   }
-  if (props.parameters !== undefined && props.parameters.length > 0) {
+  if (props.parameters?.length) {
     children.push(<GoogleStyleDocParams parameters={props.parameters} />);
   }
-  if (props.yields !== undefined) {
+  if (props.yields) {
     children.push(<GoogleStyleDocYields message={props.yields} />);
   }
-  if (props.raises !== undefined && props.raises.length > 0) {
+  if (props.raises?.length) {
     children.push(
       props.raises!.map((param) => <GoogleStyleDocRaises message={param} />),
     );
   }
-  if (props.note !== undefined) {
+  if (props.examples?.length) {
+    children.push(<GoogleStyleDocExamples items={props.examples} />);
+  }
+  if (props.seeAlso?.length) {
+    children.push(<GoogleStyleDocSeeAlso items={props.seeAlso} />);
+  }
+  if (props.warning) {
+    children.push(<GoogleStyleDocWarning message={props.warning} />);
+  }
+  if (props.deprecated) {
+    children.push(<GoogleStyleDocDeprecated message={props.deprecated} />);
+  }
+  if (props.note) {
     children.push(<GoogleStyleDocNote message={props.note} />);
   }
   return <PyDoc>{children}</PyDoc>;
@@ -453,13 +535,25 @@ function GoogleStyleExceptionDoc(props: GoogleStyleExceptionDocProps) {
       <List doubleHardline>{props.description.map((param) => param)}</List>,
     );
   }
-  if (props.parameters !== undefined && props.parameters.length > 0) {
+  if (props.parameters?.length) {
     children.push(<GoogleStyleDocParams parameters={props.parameters} />);
   }
-  if (props.attributes !== undefined && props.attributes.length > 0) {
+  if (props.attributes?.length) {
     children.push(<GoogleStyleDocAttributes attributes={props.attributes} />);
   }
-  if (props.note !== undefined) {
+  if (props.examples?.length) {
+    children.push(<GoogleStyleDocExamples items={props.examples} />);
+  }
+  if (props.seeAlso?.length) {
+    children.push(<GoogleStyleDocSeeAlso items={props.seeAlso} />);
+  }
+  if (props.warning) {
+    children.push(<GoogleStyleDocWarning message={props.warning} />);
+  }
+  if (props.deprecated) {
+    children.push(<GoogleStyleDocDeprecated message={props.deprecated} />);
+  }
+  if (props.note) {
     children.push(<GoogleStyleDocNote message={props.note} />);
   }
   return <PyDoc>{children}</PyDoc>;
@@ -491,18 +585,33 @@ function GoogleStyleMethodDoc(props: GoogleStyleMethodDocProps) {
       <List doubleHardline>{props.description.map((param) => param)}</List>,
     );
   }
-  if (props.parameters !== undefined && props.parameters.length > 0) {
+  if (props.parameters?.length) {
     children.push(<GoogleStyleDocParams parameters={props.parameters} />);
   }
-  if (props.returns !== undefined) {
+  if (props.returns) {
     children.push(<GoogleStyleDocReturn message={props.returns} />);
   }
-  if (props.raises !== undefined && props.raises.length > 0) {
+  if (props.raises?.length) {
     children.push(
       props.raises!.map((param) => <GoogleStyleDocRaises message={param} />),
     );
   }
-  if (props.note !== undefined) {
+  if (props.examples?.length) {
+    children.push(<GoogleStyleDocExamples items={props.examples} />);
+  }
+  if (props.seeAlso?.length) {
+    children.push(<GoogleStyleDocSeeAlso items={props.seeAlso} />);
+  }
+  if (props.warning) {
+    children.push(<GoogleStyleDocWarning message={props.warning} />);
+  }
+  if (props.deprecated) {
+    children.push(<GoogleStyleDocDeprecated message={props.deprecated} />);
+  }
+  if (props.overrides) {
+    children.push(<GoogleStyleDocOverrides parentClass={props.overrides} />);
+  }
+  if (props.note) {
     children.push(<GoogleStyleDocNote message={props.note} />);
   }
   return <PyDoc>{children}</PyDoc>;
@@ -694,6 +803,95 @@ function GoogleStyleDocTodo(props: GoogleStyleDocTodoProps) {
           ))}
         </List>
       </Indent>
+    </>
+  );
+}
+
+interface GoogleStyleDocExamplesProps {
+  items: Children[];
+}
+
+/**
+ * A component that creates a GoogleStyleDoc block for examples.
+ */
+function GoogleStyleDocExamples(props: GoogleStyleDocExamplesProps) {
+  return (
+    <>
+      {"Examples:"}
+      <Indent>
+        <List doubleHardline>{props.items.map((item) => item)}</List>
+      </Indent>
+    </>
+  );
+}
+
+interface GoogleStyleDocSeeAlsoProps {
+  items: string[];
+}
+
+/**
+ * A component that creates a GoogleStyleDoc block for see also references.
+ */
+function GoogleStyleDocSeeAlso(props: GoogleStyleDocSeeAlsoProps) {
+  return (
+    <>
+      {"See Also:"}
+      <Indent>
+        <List hardline>
+          {props.items.map((item) => (
+            <>{item}</>
+          ))}
+        </List>
+      </Indent>
+    </>
+  );
+}
+
+interface GoogleStyleDocWarningProps {
+  message: string;
+}
+
+/**
+ * A component that creates a GoogleStyleDoc block for warnings.
+ */
+function GoogleStyleDocWarning(props: GoogleStyleDocWarningProps) {
+  return (
+    <>
+      {"Warning:"}
+      <Indent>{props.message}</Indent>
+    </>
+  );
+}
+
+interface GoogleStyleDocDeprecatedProps {
+  message: string;
+}
+
+/**
+ * A component that creates a GoogleStyleDoc block for deprecation notices.
+ */
+function GoogleStyleDocDeprecated(props: GoogleStyleDocDeprecatedProps) {
+  return (
+    <>
+      {"Deprecated:"}
+      <Indent>{props.message}</Indent>
+    </>
+  );
+}
+
+interface GoogleStyleDocOverridesProps {
+  parentClass: string;
+}
+
+/**
+ * A component that creates a GoogleStyleDoc block for overridden methods.
+ * This indicates that the method overrides a parent class method.
+ */
+function GoogleStyleDocOverrides(props: GoogleStyleDocOverridesProps) {
+  return (
+    <>
+      {"Overrides:"}
+      <Indent>{props.parentClass}</Indent>
     </>
   );
 }

--- a/packages/python/src/components/PyDoc.tsx
+++ b/packages/python/src/components/PyDoc.tsx
@@ -215,15 +215,8 @@ export function MethodDoc(props: MethodDocProps) {
   const style = props.style ?? "google";
   switch (style) {
     case "google": {
-      const defaultNote =
-        "Do not include the 'self' parameter in the Args section.";
-      const { style: _style, note, ...rest } = props;
-      return (
-        <GoogleStyleMethodDoc
-          {...(rest as GoogleStyleMethodDocProps)}
-          note={note ?? defaultNote}
-        />
-      );
+      const { style: _style, ...rest } = props;
+      return <GoogleStyleMethodDoc {...(rest as GoogleStyleMethodDocProps)} />;
     }
     default:
       return undefined;

--- a/packages/python/src/components/PyDoc.tsx
+++ b/packages/python/src/components/PyDoc.tsx
@@ -22,13 +22,13 @@ export interface FunctionDocProps {
  * A component that creates a FunctionDoc block for functions.
  */
 export function FunctionDoc(props: FunctionDocProps) {
-  const style = props.style ?? "google";
-  const { style: _style, ...rest } = props;
+  const {
+    style = "google",
+    ...rest
+  }: { style?: "google" } & GoogleStyleFunctionDocProps = props;
   switch (style) {
     case "google":
-      return (
-        <GoogleStyleFunctionDoc {...(rest as GoogleStyleFunctionDocProps)} />
-      );
+      return <GoogleStyleFunctionDoc {...rest} />;
     default:
       return undefined;
   }
@@ -50,11 +50,13 @@ export interface ClassDocProps {
  * A component that creates a ClassDoc block for classes.
  */
 export function ClassDoc(props: ClassDocProps) {
-  const style = props.style ?? "google";
-  const { style: _style, ...rest } = props;
+  const {
+    style = "google",
+    ...rest
+  }: { style?: "google" } & GoogleStyleClassDocProps = props;
   switch (style) {
     case "google":
-      return <GoogleStyleClassDoc {...(rest as GoogleStyleClassDocProps)} />;
+      return <GoogleStyleClassDoc {...rest} />;
     default:
       return undefined;
   }
@@ -75,11 +77,13 @@ export interface ModuleDocProps {
  * A component that creates a ModuleDoc block for module-level documentation.
  */
 export function ModuleDoc(props: ModuleDocProps) {
-  const style = props.style ?? "google";
-  const { style: _style, ...rest } = props;
+  const {
+    style = "google",
+    ...rest
+  }: { style?: "google" } & GoogleStyleModuleDocProps = props;
   switch (style) {
     case "google":
-      return <GoogleStyleModuleDoc {...(rest as GoogleStyleModuleDocProps)} />;
+      return <GoogleStyleModuleDoc {...rest} />;
     default:
       return undefined;
   }
@@ -100,13 +104,13 @@ export interface PropertyDocProps {
  * A component that creates a PropertyDoc block for `@property` decorated methods.
  */
 export function PropertyDoc(props: PropertyDocProps) {
-  const style = props.style ?? "google";
-  const { style: _style, ...rest } = props;
+  const {
+    style = "google",
+    ...rest
+  }: { style?: "google" } & GoogleStylePropertyDocProps = props;
   switch (style) {
     case "google":
-      return (
-        <GoogleStylePropertyDoc {...(rest as GoogleStylePropertyDocProps)} />
-      );
+      return <GoogleStylePropertyDoc {...rest} />;
     default:
       return undefined;
   }
@@ -129,13 +133,13 @@ export interface GeneratorDocProps {
  * A component that creates a GeneratorDoc block for generator functions.
  */
 export function GeneratorDoc(props: GeneratorDocProps) {
-  const style = props.style ?? "google";
-  const { style: _style, ...rest } = props;
+  const {
+    style = "google",
+    ...rest
+  }: { style?: "google" } & GoogleStyleGeneratorDocProps = props;
   switch (style) {
     case "google":
-      return (
-        <GoogleStyleGeneratorDoc {...(rest as GoogleStyleGeneratorDocProps)} />
-      );
+      return <GoogleStyleGeneratorDoc {...rest} />;
     default:
       return undefined;
   }
@@ -157,13 +161,13 @@ export interface ExceptionDocProps {
  * A component that creates an ExceptionDoc block for custom exception classes.
  */
 export function ExceptionDoc(props: ExceptionDocProps) {
-  const style = props.style ?? "google";
-  const { style: _style, ...rest } = props;
+  const {
+    style = "google",
+    ...rest
+  }: { style?: "google" } & GoogleStyleExceptionDocProps = props;
   switch (style) {
     case "google":
-      return (
-        <GoogleStyleExceptionDoc {...(rest as GoogleStyleExceptionDocProps)} />
-      );
+      return <GoogleStyleExceptionDoc {...rest} />;
     default:
       return undefined;
   }
@@ -181,13 +185,13 @@ export interface AttributeDocProps {
  * This can be used for both inline and block attribute documentation.
  */
 export function AttributeDoc(props: AttributeDocProps) {
-  const style = props.style ?? "google";
-  const { style: _style, ...rest } = props;
+  const {
+    style = "google",
+    ...rest
+  }: { style?: "google" } & GoogleStyleAttributeDocProps = props;
   switch (style) {
     case "google":
-      return (
-        <GoogleStyleAttributeDoc {...(rest as GoogleStyleAttributeDocProps)} />
-      );
+      return <GoogleStyleAttributeDoc {...rest} />;
     default:
       return undefined;
   }
@@ -212,11 +216,13 @@ export interface MethodDocProps {
  * Automatically adds a note about not including 'self' parameter if no custom note is provided.
  */
 export function MethodDoc(props: MethodDocProps) {
-  const style = props.style ?? "google";
+  const {
+    style = "google",
+    ...rest
+  }: { style?: "google" } & GoogleStyleMethodDocProps = props;
   switch (style) {
     case "google": {
-      const { style: _style, ...rest } = props;
-      return <GoogleStyleMethodDoc {...(rest as GoogleStyleMethodDocProps)} />;
+      return <GoogleStyleMethodDoc {...rest} />;
     }
     default:
       return undefined;
@@ -333,9 +339,7 @@ function GoogleStyleFunctionDoc(props: GoogleStyleFunctionDocProps) {
   // <List> would render spaces between the elements even if <Show> evaluates to false.
   const children = [];
   if (props.description !== undefined) {
-    children.push(
-      <List doubleHardline>{props.description.map((param) => param)}</List>,
-    );
+    children.push(<List doubleHardline>{props.description}</List>);
   }
   if (props.parameters?.length) {
     children.push(<GoogleStyleDocParams parameters={props.parameters} />);
@@ -379,9 +383,7 @@ function GoogleStyleClassDoc(props: GoogleStyleClassDocProps) {
   // <List> would render spaces between the elements even if <Show> evaluates to false.
   const children = [];
   if (props.description !== undefined) {
-    children.push(
-      <List doubleHardline>{props.description.map((param) => param)}</List>,
-    );
+    children.push(<List doubleHardline>{props.description}</List>);
   }
   if (props.attributes?.length) {
     children.push(<GoogleStyleDocAttributes attributes={props.attributes} />);
@@ -415,9 +417,7 @@ interface GoogleStyleModuleDocProps extends Omit<ModuleDocProps, "style"> {}
 function GoogleStyleModuleDoc(props: GoogleStyleModuleDocProps) {
   const children = [];
   if (props.description !== undefined) {
-    children.push(
-      <List doubleHardline>{props.description.map((param) => param)}</List>,
-    );
+    children.push(<List doubleHardline>{props.description}</List>);
   }
   if (props.attributes?.length) {
     children.push(<GoogleStyleDocAttributes attributes={props.attributes} />);
@@ -448,9 +448,7 @@ interface GoogleStylePropertyDocProps extends Omit<PropertyDocProps, "style"> {}
 function GoogleStylePropertyDoc(props: GoogleStylePropertyDocProps) {
   const children = [];
   if (props.description !== undefined) {
-    children.push(
-      <List doubleHardline>{props.description.map((param) => param)}</List>,
-    );
+    children.push(<List doubleHardline>{props.description}</List>);
   }
   if (props.returns) {
     children.push(<GoogleStyleDocReturn message={props.returns} />);
@@ -482,9 +480,7 @@ interface GoogleStyleGeneratorDocProps
 function GoogleStyleGeneratorDoc(props: GoogleStyleGeneratorDocProps) {
   const children = [];
   if (props.description !== undefined) {
-    children.push(
-      <List doubleHardline>{props.description.map((param) => param)}</List>,
-    );
+    children.push(<List doubleHardline>{props.description}</List>);
   }
   if (props.parameters?.length) {
     children.push(<GoogleStyleDocParams parameters={props.parameters} />);
@@ -524,9 +520,7 @@ interface GoogleStyleExceptionDocProps
 function GoogleStyleExceptionDoc(props: GoogleStyleExceptionDocProps) {
   const children = [];
   if (props.description !== undefined) {
-    children.push(
-      <List doubleHardline>{props.description.map((param) => param)}</List>,
-    );
+    children.push(<List doubleHardline>{props.description}</List>);
   }
   if (props.parameters?.length) {
     children.push(<GoogleStyleDocParams parameters={props.parameters} />);
@@ -574,9 +568,7 @@ interface GoogleStyleMethodDocProps extends Omit<MethodDocProps, "style"> {}
 function GoogleStyleMethodDoc(props: GoogleStyleMethodDocProps) {
   const children = [];
   if (props.description !== undefined) {
-    children.push(
-      <List doubleHardline>{props.description.map((param) => param)}</List>,
-    );
+    children.push(<List doubleHardline>{props.description}</List>);
   }
   if (props.parameters?.length) {
     children.push(<GoogleStyleDocParams parameters={props.parameters} />);

--- a/packages/python/src/components/SourceFile.tsx
+++ b/packages/python/src/components/SourceFile.tsx
@@ -44,6 +44,10 @@ export interface SourceFileProps {
    * Comment to add to the header, which will be rendered as a comment in the file.
    */
   headerComment?: string;
+  /**
+   * Documentation for this module, which will be rendered as a module-level docstring.
+   */
+  doc?: Children;
 }
 
 /**
@@ -60,6 +64,26 @@ export interface SourceFileProps {
  * renders to
  * ```py
  * def test():
+ *   pass
+ * ```
+ *
+ * @example
+ * With module documentation:
+ * ```tsx
+ * <SourceFile
+ *   path="utils.py"
+ *   doc={<ModuleDoc description={[<Prose>Utility functions for data processing.</Prose>]} />}
+ * >
+ *   <FunctionDeclaration name="process_data" />
+ * </SourceFile>
+ * ```
+ * renders to
+ * ```py
+ * """
+ * Utility functions for data processing.
+ * """
+ *
+ * def process_data():
  *   pass
  * ```
  */
@@ -80,6 +104,11 @@ export function SourceFile(props: SourceFileProps) {
     <CoreSourceFile path={props.path} filetype="py" reference={Reference}>
       <Show when={scope.importedModules.size > 0}>
         <ImportStatements records={scope.importedModules} />
+        <hbr />
+        <hbr />
+      </Show>
+      <Show when={props.doc !== undefined}>
+        {props.doc}
         <hbr />
         <hbr />
       </Show>

--- a/packages/python/test/pydocs.test.tsx
+++ b/packages/python/test/pydocs.test.tsx
@@ -3,7 +3,11 @@ import { d } from "@alloy-js/core/testing";
 import { describe, expect, it } from "vitest";
 import { enumModule } from "../src/builtins/python.js";
 import * as py from "../src/index.js";
-import { toSourceText } from "./utils.jsx";
+import {
+  assertFileContents,
+  toSourceText,
+  toSourceTextMultiple,
+} from "./utils.jsx";
 
 describe("PyDoc", () => {
   it("formats properly", () => {
@@ -128,151 +132,733 @@ describe("PyDocExample", () => {
   });
 });
 
-describe("GoogleStyleDocParam", () => {
-  it("name only", () => {
+describe("SimpleCommentBlock", () => {
+  it("renders simple comment block", () => {
     const res = toSourceText([
-      <py.PyDoc>
-        <py.GoogleStyleDocParam name="somebody" />
-      </py.PyDoc>,
+      <py.SimpleCommentBlock>
+        This is a simple comment block that spans multiple lines.
+      </py.SimpleCommentBlock>,
     ]);
     expect(res).toRenderTo(
       d`
-          """
-          somebody
-          """
-
-
+          # This is a simple comment block that spans multiple lines.
+          
           `,
     );
   });
-  it("name and type", () => {
+
+  it("renders comment block with line breaks", () => {
     const res = toSourceText([
-      <py.PyDoc>
-        <py.GoogleStyleDocParam name="somebody" type={{ children: "str" }} />
-      </py.PyDoc>,
+      <py.SimpleCommentBlock>
+        First line of comment.
+        <br />
+        Second line of comment.
+      </py.SimpleCommentBlock>,
     ]);
     expect(res).toRenderTo(
       d`
-          """
-          somebody (str)
-          """
-
-
+          # First line of comment. Second line of comment.
+          
           `,
     );
   });
-  it("name, type and description", () => {
+});
+
+describe("SimpleInlineComment", () => {
+  it("renders inline comment", () => {
     const res = toSourceText([
-      <py.PyDoc>
-        <py.GoogleStyleDocParam name="somebody" type={{ children: "str" }}>
-          Somebody's name.
-        </py.GoogleStyleDocParam>
-      </py.PyDoc>,
+      <>
+        x = 42
+        <py.SimpleInlineComment>
+          This is an inline comment
+        </py.SimpleInlineComment>
+      </>,
     ]);
     expect(res).toRenderTo(
       d`
-          """
-          somebody (str): Somebody's name.
-          """
-
-
+          x = 42  # This is an inline comment
           `,
     );
   });
-  it("name, type, description, and default value", () => {
+
+  it("renders inline comment with complex text", () => {
     const res = toSourceText([
-      <py.PyDoc>
-        <py.GoogleStyleDocParam
-          name="somebody"
-          type={{ children: "str" }}
-          default="John Doe"
-        >
-          Somebody's name.
-        </py.GoogleStyleDocParam>
-      </py.PyDoc>,
+      <>
+        result = calculate()
+        <py.SimpleInlineComment>
+          TODO: Add error handling here
+        </py.SimpleInlineComment>
+      </>,
     ]);
+    expect(res).toRenderTo(
+      d`
+          result = calculate()  # TODO: Add error handling here
+          `,
+    );
+  });
+});
+
+describe("SimpleInlineMemberComment", () => {
+  it("renders inline member comment", () => {
+    const res = toSourceText([
+      <>
+        status: int
+        <py.SimpleInlineMemberComment>
+          HTTP status code
+        </py.SimpleInlineMemberComment>
+      </>,
+    ]);
+    expect(res).toRenderTo(
+      d`
+          status: int  #: HTTP status code
+          `,
+    );
+  });
+
+  it("renders inline member comment for variable declaration", () => {
+    const res = toSourceText([
+      <>
+        max_retries = 3
+        <py.SimpleInlineMemberComment>
+          Maximum number of retry attempts
+        </py.SimpleInlineMemberComment>
+      </>,
+    ]);
+    expect(res).toRenderTo(
+      d`
+          max_retries = 3  #: Maximum number of retry attempts
+          `,
+    );
+  });
+});
+
+describe("New Documentation Components", () => {
+  it("ModuleDoc renders correctly", () => {
+    const res = toSourceText([
+      <py.ModuleDoc
+        description={[
+          <Prose>
+            This module demonstrates documentation as specified by the Google
+            Python Style Guide.
+          </Prose>,
+        ]}
+        attributes={[
+          {
+            name: "module_level_variable1",
+            type: { children: "int" },
+            children: "Module level variables may be documented.",
+          },
+        ]}
+        todo={[
+          "For module TODOs",
+          "You have to also use sphinx.ext.todo extension",
+        ]}
+      />,
+    ]);
+
     expect(res).toRenderTo(
       d`
         """
-        somebody (str, optional): Somebody's name. Defaults to \"John Doe\".
+        This module demonstrates documentation as specified by the Google Python Style
+        Guide.
+
+        Attributes:
+            module_level_variable1 (int): Module level variables may be documented.
+
+        Todo:
+            * For module TODOs
+            * You have to also use sphinx.ext.todo extension
         """
 
 
         `,
     );
   });
-  it("name, type, description, and optional with default value with a very long description", () => {
-    const res = toSourceText(
-      [
-        <py.PyDoc>
-          <py.GoogleStyleDocParam
-            name="somebody"
-            type={{ children: "str" }}
-            default="John Doe"
-          >
-            Somebody's name. This can be any string representing a person,
-            whether it's a first name, full name, nickname, or even a codename
-            (e.g., "Agent X"). It's used primarily for display purposes,
-            logging, or greeting messages and is not required to be unique or
-            validated unless specified by the caller.
-          </py.GoogleStyleDocParam>
-          <py.GoogleStyleDocParam name="somebody2" type={{ children: "str" }}>
-            Somebody's name. This can be any string representing a person,
-            whether it's a first name, full name, nickname, or even a codename
-            (e.g., "Agent X"). It's used primarily for display purposes,
-            logging, or greeting messages and is not required to be unique or
-            validated unless specified by the caller.
-          </py.GoogleStyleDocParam>
-        </py.PyDoc>,
-      ],
-      { printOptions: { printWidth: 80 } },
-    );
+
+  it("PropertyDoc renders correctly", () => {
+    const res = toSourceText([
+      <py.PropertyDoc
+        description={[
+          <Prose>
+            Properties should be documented in their getter method.
+          </Prose>,
+        ]}
+        returns="str: The readonly property value."
+        note="If the setter method contains notable behavior, it should be mentioned here."
+      />,
+    ]);
+
     expect(res).toRenderTo(
       d`
-          """
-          somebody (str, optional): Somebody's name. This can be any string representing a
-              person, whether it's a first name, full name, nickname, or even a codename
-              (e.g., "Agent X"). It's used primarily for display purposes, logging, or
-              greeting messages and is not required to be unique or validated unless
-              specified by the caller. Defaults to \"John Doe\".
-          
-          somebody2 (str): Somebody's name. This can be any string representing a person,
-              whether it's a first name, full name, nickname, or even a codename (e.g.,
-              "Agent X"). It's used primarily for display purposes, logging, or greeting
-              messages and is not required to be unique or validated unless specified by
-              the caller.
-          """
+        """
+        Properties should be documented in their getter method.
+
+        Returns:
+            str: The readonly property value.
+
+        Note:
+            If the setter method contains notable behavior, it should be mentioned here.
+        """
 
 
-          `,
+        `,
     );
   });
-  it("name, type, description, and optional with default value with a description containing a linebreak", () => {
-    const res = toSourceText(
-      [
-        <py.PyDoc>
-          <py.GoogleStyleDocParam
-            name="somebody"
-            type={{ children: "str" }}
-            default="John Doe"
-          >
-            Somebody's name. This is one line
-            <hbr />
-            This is another line.
-          </py.GoogleStyleDocParam>
-        </py.PyDoc>,
-      ],
-      { printOptions: { printWidth: 80 } },
-    );
+
+  it("GeneratorDoc renders correctly", () => {
+    const res = toSourceText([
+      <py.GeneratorDoc
+        description={[
+          <Prose>
+            Generators have a Yields section instead of a Returns section.
+          </Prose>,
+        ]}
+        parameters={[
+          {
+            name: "n",
+            type: { children: "int" },
+            doc: "The upper limit of the range to generate, from 0 to n - 1.",
+          },
+        ]}
+        yields="int: The next number in the range of 0 to n - 1."
+        note="Examples should be written in doctest format."
+      />,
+    ]);
+
     expect(res).toRenderTo(
       d`
-          """
-          somebody (str, optional): Somebody's name. This is one line
-              This is another line. Defaults to \"John Doe\".
-          """
+        """
+        Generators have a Yields section instead of a Returns section.
+
+        Args:
+            n (int): The upper limit of the range to generate, from 0 to n - 1.
+
+        Yields:
+            int: The next number in the range of 0 to n - 1.
+
+        Note:
+            Examples should be written in doctest format.
+        """
 
 
-          `,
+        `,
+    );
+  });
+
+  it("ExceptionDoc renders correctly", () => {
+    const res = toSourceText([
+      <py.ExceptionDoc
+        description={[
+          <Prose>Exceptions are documented in the same way as classes.</Prose>,
+        ]}
+        parameters={[
+          {
+            name: "msg",
+            type: { children: "str" },
+            doc: "Human readable string describing the exception.",
+          },
+          {
+            name: "code",
+            type: { children: "int" },
+            default: undefined,
+            doc: "Error code.",
+          },
+        ]}
+        attributes={[
+          {
+            name: "msg",
+            type: { children: "str" },
+            children: "Human readable string describing the exception.",
+          },
+          {
+            name: "code",
+            type: { children: "int" },
+            children: "Exception error code.",
+          },
+        ]}
+        note="Do not include the 'self' parameter in the Args section."
+      />,
+    ]);
+
+    expect(res).toRenderTo(
+      d`
+        """
+        Exceptions are documented in the same way as classes.
+
+        Args:
+            msg (str): Human readable string describing the exception.
+
+            code (int): Error code.
+
+        Attributes:
+            msg (str): Human readable string describing the exception.
+
+            code (int): Exception error code.
+
+        Note:
+            Do not include the 'self' parameter in the Args section.
+        """
+
+
+        `,
+    );
+  });
+
+  it("MethodDoc renders correctly with default note", () => {
+    const res = toSourceText([
+      <py.MethodDoc
+        description={[
+          <Prose>Class methods are similar to regular functions.</Prose>,
+        ]}
+        parameters={[
+          {
+            name: "param1",
+            doc: "The first parameter.",
+          },
+          {
+            name: "param2",
+            doc: "The second parameter.",
+          },
+        ]}
+        returns="True if successful, False otherwise."
+      />,
+    ]);
+
+    expect(res).toRenderTo(
+      d`
+        """
+        Class methods are similar to regular functions.
+
+        Args:
+            param1: The first parameter.
+
+            param2: The second parameter.
+
+        Returns:
+            True if successful, False otherwise.
+
+        Note:
+            Do not include the 'self' parameter in the Args section.
+        """
+
+
+        `,
+    );
+  });
+
+  it("MethodDoc renders correctly with custom note", () => {
+    const res = toSourceText([
+      <py.MethodDoc
+        description={[
+          <Prose>Class methods are similar to regular functions.</Prose>,
+        ]}
+        parameters={[
+          {
+            name: "param1",
+            doc: "The first parameter.",
+          },
+        ]}
+        returns="True if successful, False otherwise."
+        note="This method has special behavior when called multiple times."
+      />,
+    ]);
+
+    expect(res).toRenderTo(
+      d`
+        """
+        Class methods are similar to regular functions.
+
+        Args:
+            param1: The first parameter.
+
+        Returns:
+            True if successful, False otherwise.
+
+        Note:
+            This method has special behavior when called multiple times.
+        """
+
+
+        `,
+    );
+  });
+
+  it("ModuleDoc with minimal content", () => {
+    const res = toSourceText([
+      <py.ModuleDoc
+        description={[<Prose>Simple module description.</Prose>]}
+      />,
+    ]);
+
+    expect(res).toRenderTo(
+      d`
+        """
+        Simple module description.
+        """
+
+
+        `,
+    );
+  });
+
+  it("ModuleDoc with only todo items", () => {
+    const res = toSourceText([
+      <py.ModuleDoc
+        description={[<Prose>Module with pending tasks.</Prose>]}
+        todo={["Implement feature X", "Add more tests", "Update documentation"]}
+      />,
+    ]);
+
+    expect(res).toRenderTo(
+      d`
+        """
+        Module with pending tasks.
+
+        Todo:
+            * Implement feature X
+            * Add more tests
+            * Update documentation
+        """
+
+
+        `,
+    );
+  });
+
+  it("PropertyDoc minimal (description only)", () => {
+    const res = toSourceText([
+      <py.PropertyDoc
+        description={[<Prose>A simple readonly property.</Prose>]}
+      />,
+    ]);
+
+    expect(res).toRenderTo(
+      d`
+        """
+        A simple readonly property.
+        """
+
+
+        `,
+    );
+  });
+
+  it("PropertyDoc with getter and setter info", () => {
+    const res = toSourceText([
+      <py.PropertyDoc
+        description={[
+          <Prose>
+            Properties with both a getter and setter should only be documented
+            in their getter method.
+          </Prose>,
+        ]}
+        returns=":obj:`list` of :obj:`str`: The property value."
+        note="If the setter method contains notable behavior, it should be mentioned here."
+      />,
+    ]);
+
+    expect(res).toRenderTo(
+      d`
+        """
+        Properties with both a getter and setter should only be documented in their
+        getter method.
+
+        Returns:
+            :obj:\`list\` of :obj:\`str\`: The property value.
+
+        Note:
+            If the setter method contains notable behavior, it should be mentioned here.
+        """
+
+
+        `,
+    );
+  });
+
+  it("GeneratorDoc with complex parameters", () => {
+    const res = toSourceText([
+      <py.GeneratorDoc
+        description={[
+          <Prose>
+            A more complex generator example with multiple parameters.
+          </Prose>,
+        ]}
+        parameters={[
+          {
+            name: "start",
+            type: { children: "int" },
+            default: "0",
+            doc: "Starting value for the sequence.",
+          },
+          {
+            name: "stop",
+            type: { children: "int" },
+            doc: "Ending value for the sequence (exclusive).",
+          },
+          {
+            name: "step",
+            type: { children: "int" },
+            default: "1",
+            doc: "Step size between values.",
+          },
+        ]}
+        yields="int: The next number in the sequence."
+        raises={[
+          "ValueError: If step is zero.",
+          "TypeError: If parameters are not integers.",
+        ]}
+      />,
+    ]);
+
+    expect(res).toRenderTo(
+      d`
+        """
+        A more complex generator example with multiple parameters.
+
+        Args:
+            start (int, optional): Starting value for the sequence. Defaults to "0".
+
+            stop (int): Ending value for the sequence (exclusive).
+
+            step (int, optional): Step size between values. Defaults to "1".
+
+        Yields:
+            int: The next number in the sequence.
+
+        Raises:
+            ValueError: If step is zero.
+
+        Raises:
+            TypeError: If parameters are not integers.
+        """
+
+
+        `,
+    );
+  });
+
+  it("ExceptionDoc with comprehensive documentation", () => {
+    const res = toSourceText([
+      <py.ExceptionDoc
+        description={[
+          <Prose>A custom exception for authentication failures.</Prose>,
+          <Prose>
+            This exception is raised when authentication credentials are invalid
+            or when authentication tokens have expired.
+          </Prose>,
+        ]}
+        parameters={[
+          {
+            name: "message",
+            type: { children: "str" },
+            doc: "Human readable error message describing the authentication failure.",
+          },
+          {
+            name: "error_code",
+            type: { children: "int" },
+            default: "401",
+            doc: "HTTP error code associated with the authentication failure.",
+          },
+          {
+            name: "retry_after",
+            type: { children: "int" },
+            default: undefined,
+            doc: "Number of seconds to wait before retrying authentication.",
+          },
+        ]}
+        attributes={[
+          {
+            name: "message",
+            type: { children: "str" },
+            children: "The error message.",
+          },
+          {
+            name: "error_code",
+            type: { children: "int" },
+            children: "HTTP status code.",
+          },
+          {
+            name: "retry_after",
+            type: { children: "int" },
+            children: "Retry delay in seconds, if applicable.",
+          },
+        ]}
+        note="This exception should be caught and handled gracefully in production code."
+      />,
+    ]);
+
+    expect(res).toRenderTo(
+      d`
+        """
+        A custom exception for authentication failures.
+
+        This exception is raised when authentication credentials are invalid or when
+        authentication tokens have expired.
+
+        Args:
+            message (str): Human readable error message describing the authentication
+                failure.
+
+            error_code (int, optional): HTTP error code associated with the
+                authentication failure. Defaults to "401".
+
+            retry_after (int): Number of seconds to wait before retrying authentication.
+
+        Attributes:
+            message (str): The error message.
+
+            error_code (int): HTTP status code.
+
+            retry_after (int): Retry delay in seconds, if applicable.
+
+        Note:
+            This exception should be caught and handled gracefully in production code.
+        """
+
+
+        `,
+    );
+  });
+
+  it("MethodDoc with raises but no returns", () => {
+    const res = toSourceText([
+      <py.MethodDoc
+        description={[
+          <Prose>
+            A method that performs an action but doesn't return a value.
+          </Prose>,
+        ]}
+        parameters={[
+          {
+            name: "data",
+            type: { children: "bytes" },
+            doc: "Raw data to process.",
+          },
+        ]}
+        raises={[
+          "ValueError: If data is empty or invalid.",
+          "IOError: If processing fails due to I/O issues.",
+        ]}
+      />,
+    ]);
+
+    expect(res).toRenderTo(
+      d`
+        """
+        A method that performs an action but doesn't return a value.
+
+        Args:
+            data (bytes): Raw data to process.
+
+        Raises:
+            ValueError: If data is empty or invalid.
+
+        Raises:
+            IOError: If processing fails due to I/O issues.
+
+        Note:
+            Do not include the 'self' parameter in the Args section.
+        """
+
+
+        `,
+    );
+  });
+
+  it("MethodDoc with no parameters", () => {
+    const res = toSourceText([
+      <py.MethodDoc
+        description={[
+          <Prose>A simple method with no parameters (except self).</Prose>,
+        ]}
+        returns="bool: True if the operation was successful."
+        note="This is a parameterless method that only operates on instance state."
+      />,
+    ]);
+
+    expect(res).toRenderTo(
+      d`
+        """
+        A simple method with no parameters (except self).
+
+        Returns:
+            bool: True if the operation was successful.
+
+        Note:
+            This is a parameterless method that only operates on instance state.
+        """
+
+
+        `,
+    );
+  });
+
+  it("AttributeDoc standalone usage", () => {
+    const res = toSourceText([
+      <py.PyDoc>
+        <py.AttributeDoc name="connection_timeout" type={{ children: "float" }}>
+          Maximum time in seconds to wait for a connection to be established.
+        </py.AttributeDoc>
+      </py.PyDoc>,
+    ]);
+
+    expect(res).toRenderTo(
+      d`
+        """
+        connection_timeout (float): Maximum time in seconds to wait for a connection to
+            be established.
+        """
+
+
+        `,
+    );
+  });
+
+  it("GeneratorDoc with examples in description", () => {
+    const res = toSourceText([
+      <py.GeneratorDoc
+        description={[
+          <Prose>
+            Generators have a Yields section instead of a Returns section.
+          </Prose>,
+          <py.PyDocExample>
+            print([i for i in example_generator(4)])
+            <br />
+            [0, 1, 2, 3]
+          </py.PyDocExample>,
+        ]}
+        parameters={[
+          {
+            name: "n",
+            type: { children: "int" },
+            doc: "The upper limit of the range to generate, from 0 to n - 1.",
+          },
+        ]}
+        yields="int: The next number in the range of 0 to n - 1."
+        note="Examples should be written in doctest format, and should illustrate how to use the function."
+      />,
+    ]);
+
+    expect(res).toRenderTo(
+      d`
+        """
+        Generators have a Yields section instead of a Returns section.
+
+        >> print([i for i in example_generator(4)])
+        >> [0, 1, 2, 3]
+
+        Args:
+            n (int): The upper limit of the range to generate, from 0 to n - 1.
+
+        Yields:
+            int: The next number in the range of 0 to n - 1.
+
+        Note:
+            Examples should be written in doctest format, and should illustrate how to use the function.
+        """
+
+
+        `,
     );
   });
 });
@@ -294,6 +880,18 @@ describe("Full example", () => {
             print(x)
           </py.PyDocExample>,
         ]}
+        attributes={[
+          {
+            name: "attr1",
+            type: { children: "str" },
+            children: "Description of attr1.",
+          },
+          {
+            name: "attr2",
+            type: { children: "int" },
+            children: "Description of attr2.",
+          },
+        ]}
         parameters={[
           {
             name: "somebody",
@@ -307,6 +905,7 @@ describe("Full example", () => {
             doc: "Somebody's name. This can be any string representing a person, whether it's a first name, full name, nickname, or even a codename (e.g., 'Agent X'). It's used primarily for display purposes, logging, or greeting messages and is not required to be unique or validated unless specified by the caller.",
           },
         ]}
+        note="Do not include the 'self' parameter in the Args section."
         style="google"
       />
     );
@@ -341,6 +940,11 @@ describe("Full example", () => {
               >> x = "Hello"
               >> print(x)
 
+              Attributes:
+                  attr1 (str): Description of attr1.
+
+                  attr2 (int): Description of attr2.
+
               Args:
                   somebody (str, optional): Somebody's name. This can be any string
                       representing a person, whether it's a first name, full name,
@@ -354,6 +958,9 @@ describe("Full example", () => {
                       codename (e.g., 'Agent X'). It's used primarily for display
                       purposes, logging, or greeting messages and is not required to be
                       unique or validated unless specified by the caller.
+
+              Note:
+                  Do not include the 'self' parameter in the Args section.
               """
               just_name = None
               name_and_type: int = None
@@ -394,7 +1001,9 @@ describe("Full example", () => {
           },
         ]}
         returns="The return value. True for success, False otherwise."
+        yields="int: The next number in the sequence."
         raises={["ValueError: If somebody2 is equal to somebody."]}
+        note="This function can be used as both a regular function and a generator."
         style="google"
       />
     );
@@ -446,8 +1055,14 @@ describe("Full example", () => {
               Returns:
                   The return value. True for success, False otherwise.
 
+              Yields:
+                  int: The next number in the sequence.
+
               Raises:
                   ValueError: If somebody2 is equal to somebody.
+
+              Note:
+                  This function can be used as both a regular function and a generator.
               """
               just_name = None
               name_and_type: number = None
@@ -507,5 +1122,307 @@ describe("Full example", () => {
 
     `;
     expect(result).toRenderTo(expected);
+  });
+
+  it("ModuleDoc with SourceFile integration", () => {
+    const moduleDoc = (
+      <py.ModuleDoc
+        description={[
+          <Prose>
+            This module provides utility functions for data processing. It
+            includes functions for validation, transformation, and analysis.
+          </Prose>,
+        ]}
+        attributes={[
+          {
+            name: "DEFAULT_TIMEOUT",
+            type: { children: "int" },
+            children: "Default timeout value in seconds.",
+          },
+          {
+            name: "MAX_RETRIES",
+            type: { children: "int" },
+            children: "Maximum number of retry attempts.",
+          },
+        ]}
+        todo={["Add caching functionality", "Improve error messages"]}
+        style="google"
+      />
+    );
+
+    const content = (
+      <py.SourceFile path="utils.py" doc={moduleDoc}>
+        <py.VariableDeclaration name="DEFAULT_TIMEOUT" initializer={30} />
+        <py.VariableDeclaration name="MAX_RETRIES" initializer={3} />
+        <py.FunctionDeclaration name="process_data">
+          pass
+        </py.FunctionDeclaration>
+      </py.SourceFile>
+    );
+
+    const res = toSourceTextMultiple([content]);
+    const file = res.contents.find(
+      (f) => f.kind === "file" && f.path === "utils.py",
+    );
+    expect(file).toBeDefined();
+
+    assertFileContents(res, {
+      "utils.py": d`
+        """
+        This module provides utility functions for data processing. It includes
+        functions for validation, transformation, and analysis.
+
+        Attributes:
+            DEFAULT_TIMEOUT (int): Default timeout value in seconds.
+
+            MAX_RETRIES (int): Maximum number of retry attempts.
+
+        Todo:
+            * Add caching functionality
+            * Improve error messages
+        """
+
+
+        default_timeout = 30
+
+        max_retries = 3
+
+        def process_data():
+            pass
+
+
+        `,
+    });
+  });
+
+  it("GeneratorDoc with FunctionDeclaration integration", () => {
+    const generatorDoc = (
+      <py.GeneratorDoc
+        description={[
+          <Prose>
+            A generator function that yields fibonacci numbers. This is an
+            efficient way to generate the sequence on demand.
+          </Prose>,
+        ]}
+        parameters={[
+          {
+            name: "n",
+            type: { children: "int" },
+            doc: "Number of fibonacci numbers to generate.",
+          },
+        ]}
+        yields="int: The next fibonacci number in the sequence."
+        style="google"
+      />
+    );
+
+    const result = toSourceText([
+      <py.FunctionDeclaration name="fibonacci_generator" doc={generatorDoc}>
+        yield 0
+      </py.FunctionDeclaration>,
+    ]);
+
+    expect(result).toRenderTo(
+      d`
+        def fibonacci_generator():
+            """
+            A generator function that yields fibonacci numbers. This is an efficient way
+            to generate the sequence on demand.
+
+            Args:
+                n (int): Number of fibonacci numbers to generate.
+
+            Yields:
+                int: The next fibonacci number in the sequence.
+            """
+            yield 0
+
+
+        `,
+    );
+  });
+
+  it("ExceptionDoc with ClassDeclaration integration", () => {
+    const exceptionDoc = (
+      <py.ExceptionDoc
+        description={[
+          <Prose>
+            Custom exception raised when data validation fails. This exception
+            includes details about the validation error.
+          </Prose>,
+        ]}
+        attributes={[
+          {
+            name: "field_name",
+            type: { children: "str" },
+            children: "Name of the field that failed validation.",
+          },
+          {
+            name: "error_code",
+            type: { children: "int" },
+            children: "Numeric error code for the validation failure.",
+          },
+        ]}
+        style="google"
+      />
+    );
+
+    const result = toSourceText([
+      <py.ClassDeclaration
+        name="ValidationError"
+        bases={["Exception"]}
+        doc={exceptionDoc}
+      >
+        <py.StatementList>
+          <py.VariableDeclaration
+            name="field_name"
+            type={{ children: "str" }}
+          />
+          <py.VariableDeclaration
+            name="error_code"
+            type={{ children: "int" }}
+          />
+        </py.StatementList>
+      </py.ClassDeclaration>,
+    ]);
+
+    expect(result).toRenderTo(
+      d`
+        class ValidationError(Exception):
+            """
+            Custom exception raised when data validation fails. This exception includes
+            details about the validation error.
+
+            Attributes:
+                field_name (str): Name of the field that failed validation.
+
+                error_code (int): Numeric error code for the validation failure.
+            """
+            field_name: str = None
+            error_code: int = None
+
+
+        `,
+    );
+  });
+
+  it("PropertyDoc with FunctionDeclaration (as property method) integration", () => {
+    const propertyDoc = (
+      <py.PropertyDoc
+        description={[
+          <Prose>
+            The full name of the person, combining first and last name. This
+            property automatically formats the name with proper capitalization.
+          </Prose>,
+        ]}
+        style="google"
+      />
+    );
+
+    const result = toSourceText([
+      <py.ClassDeclaration name="Person">
+        <py.PropertyDeclaration
+          name="full_name"
+          doc={propertyDoc}
+          type={{ children: "str" }}
+        >
+          return "John Doe"
+        </py.PropertyDeclaration>
+      </py.ClassDeclaration>,
+    ]);
+
+    expect(result).toRenderTo(
+      d`
+        class Person:
+            @property
+            def full_name(self) -> str:
+                """
+                The full name of the person, combining first and last name. This
+                property automatically formats the name with proper capitalization.
+                """
+                return "John Doe"
+
+
+
+
+
+        `,
+    );
+  });
+
+  it("MethodDoc with FunctionDeclaration (inside class) integration", () => {
+    const methodDoc = (
+      <py.MethodDoc
+        description={[
+          <Prose>
+            Validates the input data according to the defined schema. This
+            method performs comprehensive validation including type checking.
+          </Prose>,
+        ]}
+        parameters={[
+          {
+            name: "data",
+            type: { children: "dict" },
+            doc: "The data dictionary to validate.",
+          },
+          {
+            name: "strict",
+            type: { children: "bool" },
+            default: "True",
+            doc: "Whether to enforce strict validation rules.",
+          },
+        ]}
+        returns="bool: True if validation passes, False otherwise."
+        raises={["ValidationError: If data format is invalid."]}
+        note="This method modifies the internal validation state."
+        style="google"
+      />
+    );
+
+    const result = toSourceText([
+      <py.ClassDeclaration name="DataValidator">
+        <py.MethodDeclaration
+          name="validate"
+          doc={methodDoc}
+          parameters={[
+            { name: "data", type: { children: "dict" } },
+            { name: "strict", type: { children: "bool" }, default: true },
+          ]}
+          returnType={{ children: "bool" }}
+        >
+          return self.validate(data, strict)
+        </py.MethodDeclaration>
+      </py.ClassDeclaration>,
+    ]);
+
+    expect(result).toRenderTo(
+      d`
+        class DataValidator:
+            def validate(self, data: dict, strict: bool = True) -> bool:
+                """
+                Validates the input data according to the defined schema. This method
+                performs comprehensive validation including type checking.
+
+                Args:
+                    data (dict): The data dictionary to validate.
+
+                    strict (bool, optional): Whether to enforce strict validation rules.
+                        Defaults to "True".
+
+                Returns:
+                    bool: True if validation passes, False otherwise.
+
+                Raises:
+                    ValidationError: If data format is invalid.
+
+                Note:
+                    This method modifies the internal validation state.
+                """
+                return self.validate(data, strict)
+
+
+
+        `,
+    );
   });
 });

--- a/packages/python/test/pydocs.test.tsx
+++ b/packages/python/test/pydocs.test.tsx
@@ -249,6 +249,10 @@ describe("New Documentation Components", () => {
             children: "Module level variables may be documented.",
           },
         ]}
+        examples={[<py.PyDocExample>print("mod")</py.PyDocExample>]}
+        seeAlso={["another_module.func", "RelatedClass"]}
+        warning="Internal API."
+        deprecated="Use new_module instead."
         todo={[
           "For module TODOs",
           "You have to also use sphinx.ext.todo extension",
@@ -264,6 +268,19 @@ describe("New Documentation Components", () => {
 
         Attributes:
             module_level_variable1 (int): Module level variables may be documented.
+
+        Examples:
+            >> print("mod")
+
+        See Also:
+            another_module.func
+            RelatedClass
+
+        Warning:
+            Internal API.
+
+        Deprecated:
+            Use new_module instead.
 
         Todo:
             * For module TODOs
@@ -284,6 +301,10 @@ describe("New Documentation Components", () => {
           </Prose>,
         ]}
         returns="str: The readonly property value."
+        examples={[<py.PyDocExample>print(obj.name)</py.PyDocExample>]}
+        seeAlso={["other_property"]}
+        warning="Access may be slow."
+        deprecated="Use full_name instead."
         note="If the setter method contains notable behavior, it should be mentioned here."
       />,
     ]);
@@ -295,6 +316,18 @@ describe("New Documentation Components", () => {
 
         Returns:
             str: The readonly property value.
+
+        Examples:
+            >> print(obj.name)
+
+        See Also:
+            other_property
+
+        Warning:
+            Access may be slow.
+
+        Deprecated:
+            Use full_name instead.
 
         Note:
             If the setter method contains notable behavior, it should be mentioned here.
@@ -321,6 +354,10 @@ describe("New Documentation Components", () => {
           },
         ]}
         yields="int: The next number in the range of 0 to n - 1."
+        examples={[<py.PyDocExample>print(next(gen))</py.PyDocExample>]}
+        seeAlso={["make_generator"]}
+        warning="Do not consume in tight loops without sleep."
+        deprecated="Use new_generator instead."
         note="Examples should be written in doctest format."
       />,
     ]);
@@ -335,6 +372,18 @@ describe("New Documentation Components", () => {
 
         Yields:
             int: The next number in the range of 0 to n - 1.
+
+        Examples:
+            >> print(next(gen))
+
+        See Also:
+            make_generator
+
+        Warning:
+            Do not consume in tight loops without sleep.
+
+        Deprecated:
+            Use new_generator instead.
 
         Note:
             Examples should be written in doctest format.
@@ -376,6 +425,8 @@ describe("New Documentation Components", () => {
             children: "Exception error code.",
           },
         ]}
+        seeAlso={["BaseException"]}
+        deprecated="Use NewException instead."
         note="Do not include the 'self' parameter in the Args section."
       />,
     ]);
@@ -394,6 +445,12 @@ describe("New Documentation Components", () => {
             msg (str): Human readable string describing the exception.
 
             code (int): Exception error code.
+
+        See Also:
+            BaseException
+
+        Deprecated:
+            Use NewException instead.
 
         Note:
             Do not include the 'self' parameter in the Args section.
@@ -421,6 +478,7 @@ describe("New Documentation Components", () => {
           },
         ]}
         returns="True if successful, False otherwise."
+        overrides="Base.method"
       />,
     ]);
 
@@ -436,6 +494,9 @@ describe("New Documentation Components", () => {
 
         Returns:
             True if successful, False otherwise.
+
+        Overrides:
+            Base.method
 
         Note:
             Do not include the 'self' parameter in the Args section.
@@ -892,6 +953,10 @@ describe("Full example", () => {
             children: "Description of attr2.",
           },
         ]}
+        examples={[<py.PyDocExample>print("class-doc")</py.PyDocExample>]}
+        seeAlso={["RelatedClass", "helper_function"]}
+        warning="This class is experimental."
+        deprecated="Use NewClass instead."
         parameters={[
           {
             name: "somebody",
@@ -958,6 +1023,19 @@ describe("Full example", () => {
                       codename (e.g., 'Agent X'). It's used primarily for display
                       purposes, logging, or greeting messages and is not required to be
                       unique or validated unless specified by the caller.
+
+              Examples:
+                  >> print("class-doc")
+
+              See Also:
+                  RelatedClass
+                  helper_function
+
+              Warning:
+                  This class is experimental.
+
+              Deprecated:
+                  Use NewClass instead.
 
               Note:
                   Do not include the 'self' parameter in the Args section.

--- a/packages/python/test/pydocs.test.tsx
+++ b/packages/python/test/pydocs.test.tsx
@@ -461,7 +461,7 @@ describe("New Documentation Components", () => {
     );
   });
 
-  it("MethodDoc renders correctly with default note", () => {
+  it("MethodDoc renders correctly without default note", () => {
     const res = toSourceText([
       <py.MethodDoc
         description={[
@@ -497,9 +497,6 @@ describe("New Documentation Components", () => {
 
         Overrides:
             Base.method
-
-        Note:
-            Do not include the 'self' parameter in the Args section.
         """
 
 
@@ -816,9 +813,6 @@ describe("New Documentation Components", () => {
 
         Raises:
             IOError: If processing fails due to I/O issues.
-
-        Note:
-            Do not include the 'self' parameter in the Args section.
         """
 
 

--- a/packages/python/test/sourcefiles.test.tsx
+++ b/packages/python/test/sourcefiles.test.tsx
@@ -1,7 +1,12 @@
+import { Prose } from "@alloy-js/core";
 import { d } from "@alloy-js/core/testing";
 import { expect, it } from "vitest";
 import * as py from "../src/index.js";
-import { toSourceText } from "./utils.jsx";
+import {
+  assertFileContents,
+  toSourceText,
+  toSourceTextMultiple,
+} from "./utils.jsx";
 
 /**
  * toSourceText wraps the children in a SourceFile component
@@ -137,4 +142,98 @@ it("correct formatting of source file", () => {
 
   `;
   expect(result).toRenderTo(expected);
+});
+
+it("renders module documentation correctly", () => {
+  const moduleDoc = (
+    <py.ModuleDoc
+      description={[
+        <Prose>
+          This module provides utility functions for data processing. It
+          includes functions for validation, transformation, and analysis.
+        </Prose>,
+      ]}
+      attributes={[
+        {
+          name: "DEFAULT_TIMEOUT",
+          type: { children: "int" },
+          children: "Default timeout value in seconds.",
+        },
+        {
+          name: "MAX_RETRIES",
+          type: { children: "int" },
+          children: "Maximum number of retry attempts.",
+        },
+      ]}
+      todo={["Add caching functionality", "Improve error messages"]}
+      style="google"
+    />
+  );
+
+  const content = (
+    <py.SourceFile path="utils.py" doc={moduleDoc}>
+      <py.VariableDeclaration name="DEFAULT_TIMEOUT" initializer={30} />
+      <py.VariableDeclaration name="MAX_RETRIES" initializer={3} />
+      <py.FunctionDeclaration name="process_data">pass</py.FunctionDeclaration>
+    </py.SourceFile>
+  );
+
+  const res = toSourceTextMultiple([content]);
+  const file = res.contents.find(
+    (f) => f.kind === "file" && f.path === "utils.py",
+  );
+  expect(file).toBeDefined();
+
+  assertFileContents(res, {
+    "utils.py": d`
+        """
+        This module provides utility functions for data processing. It includes
+        functions for validation, transformation, and analysis.
+
+        Attributes:
+            DEFAULT_TIMEOUT (int): Default timeout value in seconds.
+
+            MAX_RETRIES (int): Maximum number of retry attempts.
+
+        Todo:
+            * Add caching functionality
+            * Improve error messages
+        """
+
+
+        default_timeout = 30
+
+        max_retries = 3
+
+        def process_data():
+            pass
+
+
+        `,
+  });
+});
+
+it("renders source file without documentation correctly", () => {
+  const content = (
+    <py.SourceFile path="simple.py">
+      <py.FunctionDeclaration name="hello_world">
+        print("Hello, World!")
+      </py.FunctionDeclaration>
+    </py.SourceFile>
+  );
+
+  const res = toSourceTextMultiple([content]);
+  const file = res.contents.find(
+    (f) => f.kind === "file" && f.path === "simple.py",
+  );
+  expect(file).toBeDefined();
+
+  assertFileContents(res, {
+    "simple.py": d`
+        def hello_world():
+            print("Hello, World!")
+
+
+        `,
+  });
 });


### PR DESCRIPTION
Splits docs components into separate components:
- ClassDoc
- FunctionDoc
- MethodDoc
- ModuleDoc
- PropertyDoc
- GeneratorDoc
- ExceptionDoc
- AttributeDoc

These are the only components that are meant to be used directly, and are the only ones that are exported.

Also added the equivalent GoogleStyle-prefixed classes, bringing the Google-style implementation of these.