### PR TITLE
Create KeywordArgument component

### DIFF
--- a/.chronus/changes/feature-no-symbol-for-call-statement-var-2026-2024-18-02-00.md
+++ b/.chronus/changes/feature-no-symbol-for-call-statement-var-2026-2024-18-02-00.md
@@ -1,0 +1,7 @@
+---
+changeKind: feature
+packages:
+  - "@alloy-js/python"
+---
+
+Add new `KeywordArgument` component to handle the special behavior when it comes to not creating symbols.

--- a/packages/python/src/components/KeywordArgument.tsx
+++ b/packages/python/src/components/KeywordArgument.tsx
@@ -1,0 +1,50 @@
+import { Children, memo } from "@alloy-js/core";
+import { usePythonNamePolicy } from "../name-policy.js";
+import { Atom } from "./Atom.jsx";
+
+export interface KeywordArgumentProps {
+  /**
+   * The name of the keyword argument.
+   */
+  name: string;
+  /**
+   * The value of the keyword argument.
+   */
+  value: Children;
+}
+
+/**
+ * A keyword argument component for Python function calls.
+ *
+ * This renders keyword arguments like `name=value` in function calls.
+ * Unlike VariableDeclaration, this does not create a symbol or register
+ * in any scope.
+ *
+ * @example
+ * ```tsx
+ * <FunctionCallExpression
+ *   target="my_func"
+ *   args={[
+ *     <KeywordArgument name="foo" value={42} />,
+ *     <KeywordArgument name="bar" value="hello" />,
+ *   ]}
+ * />
+ * ```
+ * renders to
+ * ```py
+ * my_func(foo=42, bar="hello")
+ * ```
+ */
+export function KeywordArgument(props: KeywordArgumentProps) {
+  const namePolicy = usePythonNamePolicy();
+  const name = namePolicy.getName(props.name, "variable");
+
+  const value =
+    typeof props.value === "object" ? memo(() => props.value) : props.value;
+
+  return (
+    <>
+      {name}=<Atom jsValue={value} />
+    </>
+  );
+}

--- a/packages/python/src/components/KeywordArgument.tsx
+++ b/packages/python/src/components/KeywordArgument.tsx
@@ -1,12 +1,13 @@
-import { Children, memo } from "@alloy-js/core";
+import { Children, isNamekey, memo, Namekey } from "@alloy-js/core";
 import { usePythonNamePolicy } from "../name-policy.js";
 import { Atom } from "./Atom.jsx";
 
 export interface KeywordArgumentProps {
   /**
-   * The name of the keyword argument.
+   * The name of the keyword argument. Can be a string or a Namekey.
+   * Using a Namekey is useful when you want to match a function parameter's name.
    */
-  name: string;
+  name: string | Namekey;
   /**
    * The value of the keyword argument.
    */
@@ -37,7 +38,8 @@ export interface KeywordArgumentProps {
  */
 export function KeywordArgument(props: KeywordArgumentProps) {
   const namePolicy = usePythonNamePolicy();
-  const name = namePolicy.getName(props.name, "variable");
+  const rawName = isNamekey(props.name) ? props.name.name : props.name;
+  const name = namePolicy.getName(rawName, "variable");
 
   const value =
     typeof props.value === "object" ? memo(() => props.value) : props.value;

--- a/packages/python/src/components/VariableDeclaration.tsx
+++ b/packages/python/src/components/VariableDeclaration.tsx
@@ -6,6 +6,7 @@ import {
   createSymbolSlot,
   memo,
 } from "@alloy-js/core";
+import { usePythonNamePolicy } from "../name-policy.js";
 import { createPythonSymbol } from "../symbol-creation.js";
 import { Atom } from "./Atom.jsx";
 import { BaseDeclarationProps } from "./Declaration.jsx";
@@ -74,17 +75,21 @@ export function VariableDeclaration(props: VariableDeclarationProps) {
   const TypeSymbolSlot = createSymbolSlot();
   const ValueTypeSymbolSlot = createSymbolSlot();
 
-  const sym = createPythonSymbol(
-    props.name,
-    {
-      instance: props.instanceVariable,
-      refkeys: props.refkey,
-      type: props.type ? TypeSymbolSlot.firstSymbol : undefined,
-    },
-    "variable",
-  );
+  // For callStatementVar, don't create a symbol (keyword arguments aren't variables)
+  const sym =
+    props.callStatementVar ? undefined : (
+      createPythonSymbol(
+        props.name,
+        {
+          instance: props.instanceVariable,
+          refkeys: props.refkey,
+          type: props.type ? TypeSymbolSlot.firstSymbol : undefined,
+        },
+        "variable",
+      )
+    );
 
-  if (!props.type) {
+  if (!props.type && sym) {
     ValueTypeSymbolSlot.moveMembersTo(sym);
   }
 
@@ -133,13 +138,32 @@ export function VariableDeclaration(props: VariableDeclarationProps) {
     ];
   };
   const [renderRightSideOperator, rightSide] = getRightSide();
+
+  // For callStatementVar, render without symbol registration
+  // We need to manually apply the name policy to the name
+  // since that is normally handled by the symbol creation.
+  if (props.callStatementVar) {
+    const namePolicy = usePythonNamePolicy();
+    const name =
+      typeof props.name === "string" && props.name ?
+        namePolicy.getName(props.name, "variable")
+      : "";
+    return (
+      <>
+        {name}
+        {renderRightSideOperator && assignmentOperator}
+        {rightSide}
+      </>
+    );
+  }
+
   return (
     <>
       <Show when={Boolean(props.doc)}>
         <SimpleCommentBlock children={props.doc} />
         <hbr />
       </Show>
-      <CoreDeclaration symbol={sym}>
+      <CoreDeclaration symbol={sym!}>
         {<Name />}
         {type}
         {renderRightSideOperator && assignmentOperator}

--- a/packages/python/src/components/index.ts
+++ b/packages/python/src/components/index.ts
@@ -14,6 +14,7 @@ export * from "./FunctionCallExpression.js";
 export * from "./FunctionDeclaration.js";
 export * from "./FutureStatement.js";
 export * from "./ImportStatement.js";
+export * from "./KeywordArgument.js";
 export * from "./LexicalScope.js";
 export * from "./MemberExpression.js";
 export * from "./MemberScope.jsx";

--- a/packages/python/test/classinstantiations.test.tsx
+++ b/packages/python/test/classinstantiations.test.tsx
@@ -72,27 +72,15 @@ it("Class instantiation without a reference", () => {
   expect(result).toRenderTo(expected);
 });
 
-it("Class instantiation without a reference and with call statement vars", () => {
+it("Class instantiation without a reference and with keyword arguments", () => {
   const result = toSourceText([
     <py.StatementList>
       <py.ClassInstantiation
         target={"ExampleClass"}
         args={[
-          <py.VariableDeclaration
-            name="name"
-            initializer={"A name"}
-            callStatementVar
-          />,
-          <py.VariableDeclaration
-            name="number"
-            initializer={42}
-            callStatementVar
-          />,
-          <py.VariableDeclaration
-            name="flag"
-            initializer={true}
-            callStatementVar
-          />,
+          <py.KeywordArgument name="name" value={"A name"} />,
+          <py.KeywordArgument name="number" value={42} />,
+          <py.KeywordArgument name="flag" value={true} />,
         ]}
       />
     </py.StatementList>,
@@ -103,23 +91,15 @@ it("Class instantiation without a reference and with call statement vars", () =>
   expect(result).toRenderTo(expected);
 });
 
-it("Class instantiation without a reference mixing unnamed and named vars", () => {
+it("Class instantiation without a reference mixing unnamed and keyword arguments", () => {
   const result = toSourceText([
     <py.StatementList>
       <py.ClassInstantiation
         target={"ExampleClass"}
         args={[
           <py.Atom jsValue={"A name"} />,
-          <py.VariableDeclaration
-            name="number"
-            initializer={42}
-            callStatementVar
-          />,
-          <py.VariableDeclaration
-            name="flag"
-            initializer={true}
-            callStatementVar
-          />,
+          <py.KeywordArgument name="number" value={42} />,
+          <py.KeywordArgument name="flag" value={true} />,
         ]}
       />
     </py.StatementList>,

--- a/packages/python/test/functioncallexpressions.test.tsx
+++ b/packages/python/test/functioncallexpressions.test.tsx
@@ -142,4 +142,67 @@ describe("FunctionCallExpression", () => {
     `;
     expect(result).toRenderTo(expected);
   });
+
+  it("keyword argument name does not conflict with same-named variable", () => {
+    const resKey = refkey();
+    const kwargsKey = refkey();
+    const result = toSourceText([
+      <py.StatementList>
+        <py.VariableDeclaration
+          name="kwargs"
+          refkey={kwargsKey}
+          initializer={<py.Atom jsValue={{}} />}
+        />
+        <py.VariableDeclaration
+          name="res"
+          refkey={resKey}
+          initializer={
+            <py.FunctionCallExpression
+              target="resolve_with_adapter"
+              args={[
+                "obj",
+                "info",
+                <py.VariableDeclaration
+                  name="operation"
+                  initializer={<>Operation.QUERY</>}
+                  callStatementVar
+                />,
+                <py.VariableDeclaration
+                  name="data"
+                  initializer={kwargsKey}
+                  callStatementVar
+                />,
+                <py.VariableDeclaration
+                  name="is_v5"
+                  initializer={true}
+                  callStatementVar
+                />,
+              ]}
+            />
+          }
+        />
+        <py.VariableDeclaration
+          name="data"
+          initializer={
+            <py.MemberExpression>
+              <py.MemberExpression.Part refkey={resKey} />
+              <py.MemberExpression.Part key={"data"} />
+            </py.MemberExpression>
+          }
+        />
+      </py.StatementList>,
+    ]);
+    const expected = d`
+      kwargs = {}
+      res = resolve_with_adapter(
+          obj,
+          info,
+          operation=Operation.QUERY,
+          data=kwargs,
+          is_v5=True
+      )
+      data = res["data"]
+    `;
+    expect(result).toRenderTo(expected);
+  });
 });

--- a/packages/python/test/functioncallexpressions.test.tsx
+++ b/packages/python/test/functioncallexpressions.test.tsx
@@ -85,27 +85,15 @@ describe("FunctionCallExpression", () => {
     expect(result).toRenderTo(expected);
   });
 
-  it("Method call without a reference and with call statement vars", () => {
+  it("Method call without a reference and with keyword arguments", () => {
     const result = toSourceText([
       <py.StatementList>
         <py.FunctionCallExpression
           target={"example_method"}
           args={[
-            <py.VariableDeclaration
-              name="name"
-              initializer={"A name"}
-              callStatementVar
-            />,
-            <py.VariableDeclaration
-              name="number"
-              initializer={42}
-              callStatementVar
-            />,
-            <py.VariableDeclaration
-              name="flag"
-              initializer={true}
-              callStatementVar
-            />,
+            <py.KeywordArgument name="name" value={"A name"} />,
+            <py.KeywordArgument name="number" value={42} />,
+            <py.KeywordArgument name="flag" value={true} />,
           ]}
         />
       </py.StatementList>,
@@ -116,23 +104,15 @@ describe("FunctionCallExpression", () => {
     expect(result).toRenderTo(expected);
   });
 
-  it("Method call without a reference mixing unnamed and named vars", () => {
+  it("Method call without a reference mixing unnamed and keyword arguments", () => {
     const result = toSourceText([
       <py.StatementList>
         <py.FunctionCallExpression
           target={"example_method"}
           args={[
             <py.Atom jsValue={"A name"} />,
-            <py.VariableDeclaration
-              name="number"
-              initializer={42}
-              callStatementVar
-            />,
-            <py.VariableDeclaration
-              name="flag"
-              initializer={true}
-              callStatementVar
-            />,
+            <py.KeywordArgument name="number" value={42} />,
+            <py.KeywordArgument name="flag" value={true} />,
           ]}
         />
       </py.StatementList>,
@@ -162,21 +142,12 @@ describe("FunctionCallExpression", () => {
               args={[
                 "obj",
                 "info",
-                <py.VariableDeclaration
+                <py.KeywordArgument
                   name="operation"
-                  initializer={<>Operation.QUERY</>}
-                  callStatementVar
+                  value={<>Operation.QUERY</>}
                 />,
-                <py.VariableDeclaration
-                  name="data"
-                  initializer={kwargsKey}
-                  callStatementVar
-                />,
-                <py.VariableDeclaration
-                  name="is_v5"
-                  initializer={true}
-                  callStatementVar
-                />,
+                <py.KeywordArgument name="data" value={kwargsKey} />,
+                <py.KeywordArgument name="is_v5" value={true} />,
               ]}
             />
           }

--- a/packages/python/test/keywordargument.test.tsx
+++ b/packages/python/test/keywordargument.test.tsx
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+import * as py from "../src/index.js";
+import { toSourceText } from "./utils.jsx";
+
+describe("KeywordArgument", () => {
+  it("renders a keyword argument", () => {
+    const res = toSourceText([
+      <py.KeywordArgument name="callStmtVar" value={12} />,
+    ]);
+    expect(res).toBe(`call_stmt_var=12`);
+  });
+});

--- a/packages/python/test/keywordargument.test.tsx
+++ b/packages/python/test/keywordargument.test.tsx
@@ -1,12 +1,21 @@
+import { namekey } from "@alloy-js/core";
 import { describe, expect, it } from "vitest";
 import * as py from "../src/index.js";
 import { toSourceText } from "./utils.jsx";
 
 describe("KeywordArgument", () => {
-  it("renders a keyword argument", () => {
+  it("renders a keyword argument with string name", () => {
     const res = toSourceText([
       <py.KeywordArgument name="callStmtVar" value={12} />,
     ]);
     expect(res).toBe(`call_stmt_var=12`);
+  });
+
+  it("renders a keyword argument with namekey", () => {
+    const paramName = namekey("myParam");
+    const res = toSourceText([
+      <py.KeywordArgument name={paramName} value={42} />,
+    ]);
+    expect(res).toBe(`my_param=42`);
   });
 });

--- a/packages/python/test/namepolicies.test.tsx
+++ b/packages/python/test/namepolicies.test.tsx
@@ -82,15 +82,13 @@ it("correct formatting of call statement vars", () => {
       <py.ClassInstantiation
         target={"test"}
         args={[
-          <py.VariableDeclaration
+          <py.KeywordArgument
             name="this-is-a-long-name"
-            initializer={<py.Atom jsValue={"A name"} />}
-            callStatementVar
+            value={<py.Atom jsValue={"A name"} />}
           />,
-          <py.VariableDeclaration
+          <py.KeywordArgument
             name="andThisIsANumber"
-            initializer={<py.Atom jsValue={42} />}
-            callStatementVar
+            value={<py.Atom jsValue={42} />}
           />,
         ]}
       />

--- a/packages/python/test/variables.test.tsx
+++ b/packages/python/test/variables.test.tsx
@@ -95,28 +95,6 @@ describe("Python Variable", () => {
     expect(res).toBe(`omit_none_var: int`);
   });
 
-  it("declares a call statement python variable", () => {
-    const res = toSourceText([
-      <py.VariableDeclaration
-        name="callStmtVar"
-        initializer={12}
-        callStatementVar={true}
-      />,
-    ]);
-    expect(res).toBe(`call_stmt_var=12`);
-  });
-
-  it("declares a call statement python variable without name", () => {
-    const res = toSourceText([
-      <py.VariableDeclaration
-        name=""
-        initializer={12}
-        callStatementVar={true}
-      />,
-    ]);
-    expect(res).toBe(`12`);
-  });
-
   it("declares a python variable with an optional type", () => {
     const res = toSourceText([
       <py.StatementList>

--- a/samples/python-example/src/components/ClientMethod.tsx
+++ b/samples/python-example/src/components/ClientMethod.tsx
@@ -68,16 +68,10 @@ export function ClientMethod(props: ClientMethodProps) {
     returnCode = code`[${responseType}(**data) for data in response.json()]`;
   }
 
-  let requestsCallArgs = [
-    <py.VariableDeclaration name="" initializer={endpoint} callStatementVar />,
-  ];
+  let requestsCallArgs = [endpoint];
   if (op.verb === "post" || op.verb === "put") {
     requestsCallArgs.push(
-      <py.VariableDeclaration
-        name="json"
-        initializer={refkey(op, "requestBody")}
-        callStatementVar
-      />,
+      <py.KeywordArgument name="json" value={refkey(op, "requestBody")} />,
     );
   }
 


### PR DESCRIPTION
A name conflict was happening when we had a function call parameter with the same name as a variable.

This was happening because we were creating keyword argument using Variable Declarations with a `callStatementVar` flag as true, which was registering symbols, which we didn't need to for this scenario.

As we were more and more creating different flows to handle `callStatementVar`, we are creating `KeywordArgument` to handle what `callStatementVar` handled, but also making this component to not register symbols anymore.

We are also explicitly removing the doc support on this new component as, due to how the components are structures are currently called and structured, we wouldn't be able to render the doc for the var.